### PR TITLE
new:usr: Allow custom story formatting in club find

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This is a command line interface for [Clubhouse](https://app.clubhouse.io), focu
   Options:
 
     -a, --archived          Include archived Stories
-    -I, --idonly            Print only ID of story results
+    -q, --quiet             Print only story output, no loading dialog
     -l, --label [id|name]   Stories with label id/name, by regex
     -o, --owner [name]      Stories with owner, by regex
     -p, --project [id|name] Stories in project
@@ -83,6 +83,8 @@ $ club find -o 'josh' -s 'Review' -f $'%i\t%s\t%t\n\t%o'
 
 #### Story Output Formatting
 
+Templating variables:
+
 ~~~
 %i      Print ID of story
 %t      Print title/name of story
@@ -97,6 +99,8 @@ $ club find -o 'josh' -s 'Review' -f $'%i\t%s\t%t\n\t%o'
 %c      Print story creation timestamp
 %u      Print story updated timestamp (if different from created)
 ~~~
+
+Note that the `$` string operator in bash is helpful in allowing `\t` (tab) and `\n` (newline) literals in the formatting string. Otherwise, you can actually just type a newline character.
 
 ### Stories
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,28 @@ $ club find -o 'josh' -s 'Review'
   Owners:  Josh (josh)
   State:   #500000020 Code Review
   URL:     https://app.clubhouse.io/story/1480
+
+# Custom formatting is an option
+$ club find -o 'josh' -s 'Review' -f $'%i\t%s\t%t\n\t%o'
+1480    #500000020 Code Review  Create Thinga-ma-bob
+    Josh (josh)
+~~~
+
+#### Story Output Formatting
+
+~~~
+%i      Print ID of story
+%t      Print title/name of story
+%a      Print archived status of story
+%o      Print owners of story
+%l      Print labels on story
+%u      Print URL of story
+%p      Print project of story
+%y      Print story type
+%e      Print story estimate
+%s      Print story state
+%c      Print story creation timestamp
+%u      Print story updated timestamp (if different from created)
 ~~~
 
 ### Stories

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a command line interface for [Clubhouse](https://app.clubhouse.io), focu
 ## Table of Contents
 - [Usage & Commands](#usage)
     - [Search](#search)
-    - [Stories](#stories)
+    - [Story](#story)
     - [Story Creation](#story-creation)
     - [Workspace](#workspace)
     - [Members](#members)
@@ -60,6 +60,7 @@ This is a command line interface for [Clubhouse](https://app.clubhouse.io), focu
     -S, --save [name]       Save search configuration as workspace
     -t, --text [name]       Stories with text in name, by regex
     -y, --type [name]       Stories of type, by regex
+    -f, --format [template] Format each story output by template
     -h, --help              output usage information
 ~~~
 
@@ -102,7 +103,7 @@ Templating variables:
 
 Note that the `$` string operator in bash is helpful in allowing `\t` (tab) and `\n` (newline) literals in the formatting string. Otherwise, you can actually just type a newline character.
 
-### Stories
+### Story
 
 ~~~
   Usage: club story [options] <id>

--- a/src/bin/club-find
+++ b/src/bin/club-find
@@ -10,7 +10,7 @@ program
     .description('Search through clubouse stories')
     .option('-a, --archived', 'Include archived Stories')
     .option('-c, --created [operator][date]', 'Stories created within criteria (oprateor is one of <|>|=)', '')
-    .option('-I, --idonly', 'Print only ID of story results', '')
+    .option('-q, --quiet', 'Print only story output, no loading dialog', '')
     .option('-l, --label [id|name]', 'Stories with label id/name, by regex', '')
     .option('-o, --owner [name]', 'Stories with owner, by regex', '')
     .option('-p, --project [id]', 'Stories in project', '')
@@ -24,7 +24,7 @@ program
 spin.setSpinnerString(27);
 
 const main = async () => {
-    if (!program.idonly)
+    if (!program.quiet)
         spin.start();
     let stories = [];
     try {
@@ -32,7 +32,7 @@ const main = async () => {
     } catch (e) {
         log('Error fetching stories:', e);
     }
-    if (!program.idonly)
+    if (!program.quiet)
         spin.stop(true);
     stories.map(storyLib.printStory(program));
     if (program.save) {
@@ -47,6 +47,8 @@ const main = async () => {
             type:       program.type     || undefined,
             updated:    program.updated  || undefined,
             created:    program.created  || undefined,
+            quiet:      program.quiet    || undefined,
+            format:     program.format   || undefined,
         });
         if (success) {
             log('Saved query as %s workspace', name);

--- a/src/bin/club-find
+++ b/src/bin/club-find
@@ -19,6 +19,7 @@ program
     .option('-t, --text [name]', 'Stories with text in name, by regex', '')
     .option('-u, --updated [operator][date]', 'Stories updated within criteria (oprateor is one of <|>|=)', '')
     .option('-y, --type [name]', 'Stories of type, by regex', '')
+    .option('-f, --format [template]', 'Format each story output by template', '')
     .parse(process.argv);
 spin.setSpinnerString(27);
 

--- a/src/bin/club-workspace
+++ b/src/bin/club-workspace
@@ -41,8 +41,10 @@ const main = async () => {
             log('  club find [options] --save', name);
             log('to create it.');
         } else {
-            log('Loading workspace %s:', name, toArgs(workspace));
-            log();
+            if (!program.quiet){
+                log('Loading workspace %s:', name, toArgs(workspace));
+                log();
+            }
             let stories = [];
             try {
                 stories = await storyLib.listStories(workspace);

--- a/src/lib/stories.js
+++ b/src/lib/stories.js
@@ -86,9 +86,6 @@ const filterStories = (program, projects) => { return (stories, index) => {
 };};
 
 const printStory = (program) => { return (story) => {
-    if (program.idonly) {
-        return log(story.id);
-    }
     const defaultFormat = `#%I %t
     \tType:   \t%y/%e
     \tLabels: \t%l
@@ -109,7 +106,7 @@ const printStory = (program) => { return (story) => {
     log(format
         .replace(/%I/, chalk.blue.bold(`${story.id}`))
         .replace(/%t/, chalk.blue(`${story.name}`))
-        .replace(/%d/, story.description)
+        .replace(/%d/, story.description || '')
         .replace(/%y/, story.story_type)
         .replace(/%e/, story.estimate || '_')
         .replace(/%l/, labels.join(', ') || '_')

--- a/src/lib/stories.js
+++ b/src/lib/stories.js
@@ -13,9 +13,10 @@ const listStories = async (program) => {
         client.listProjects()
     ]);
     wf = wfs[0];    // TODO: this is always getting the default workflow
+    let regexProject = new RegExp(program.project, 'i');
     const filteredProjects = projects
         .filter(p => {
-            return !!(p.id + p.name).match(new RegExp(program.project, 'i'));
+            return !!(p.id + p.name).match(regexProject);
         });
     var stories = await Promise.all(filteredProjects.map(fetchStories));
     return stories.map(filterStories(program, filteredProjects))
@@ -88,24 +89,38 @@ const printStory = (program) => { return (story) => {
     if (program.idonly) {
         return log(story.id);
     }
+    const defaultFormat = `#%I %t
+    \tType:   \t%y/%e
+    \tLabels: \t%l
+    \tProject:\t%p
+    \tOwners: \t%o
+    \tState:  \t%s
+    \tURL:    \t%u
+    \tCreated:\t%c\tUpdated: %u
+    \tArchived:\t%a
+    `;
+    const format = program.format || defaultFormat;
     const labels = story.labels.map(l => {
         return chalk.bold(`#${l.id}`) + ` ${l.name}`;
     });
     const owners = story.owners.map(o => {
         return `${o.profile.name} (` + chalk.bold(`${o.profile.mention_name}` + ')');
     });
-    log(chalk.blue.bold(`#${story.id}`) + chalk.blue(` ${story.name}`));
-    log(`  Type:     ${story.story_type}/${story.estimate || '_'}`);
-    log(`  Label:    ${labels.join(', ')}`);
-    log('  Project:  ' + chalk.bold(`#${story.project.id}`) + ` ${story.project.name}`);
-    log('  Owners:   ' + `${owners.join(', ') || '_'}`);
-    log('  State:    ' + chalk.bold(`#${story.workflow_state_id} `) + story.state.name);
-    log(`  URL:      https://app.clubhouse.io/story/${story.id}`);
-    log('  Created:  ' + `${story.created_at} ${story.updated_at != story.created_at ? 'Updated: ' + story.updated_at : ''}`);
-    if (story.archived) {
-        log('  archived: ' + chalk.bold(story.archived));
-    }
-    log();
+    log(format
+        .replace(/%I/, chalk.blue.bold(`${story.id}`))
+        .replace(/%t/, chalk.blue(`${story.name}`))
+        .replace(/%d/, story.description)
+        .replace(/%y/, story.story_type)
+        .replace(/%e/, story.estimate || '_')
+        .replace(/%l/, labels.join(', ') || '_')
+        .replace(/%p/, chalk.bold(`#${story.project.id}`) + ` ${story.project.name}`)
+        .replace(/%o/, owners.join(', ') || '_')
+        .replace(/%s/, chalk.bold(`#${story.workflow_state_id} `) + story.state.name)
+        .replace(/%u/, `https://app.clubhouse.io/story/${story.id}`)
+        .replace(/%c/, story.created_at)
+        .replace(/%u/, story.updated_at != story.created_at ? story.updated_at : '_')
+        .replace(/%a/, story.archived)
+    );
     return story;
 };};
 

--- a/src/lib/stories.js
+++ b/src/lib/stories.js
@@ -86,7 +86,7 @@ const filterStories = (program, projects) => { return (stories, index) => {
 };};
 
 const printStory = (program) => { return (story) => {
-    const defaultFormat = `#%I %t
+    const defaultFormat = `#%i %t
     \tType:   \t%y/%e
     \tLabels: \t%l
     \tProject:\t%p
@@ -104,7 +104,7 @@ const printStory = (program) => { return (story) => {
         return `${o.profile.name} (` + chalk.bold(`${o.profile.mention_name}` + ')');
     });
     log(format
-        .replace(/%I/, chalk.blue.bold(`${story.id}`))
+        .replace(/%i/, chalk.blue.bold(`${story.id}`))
         .replace(/%t/, chalk.blue(`${story.name}`))
         .replace(/%d/, story.description || '')
         .replace(/%y/, story.story_type)


### PR DESCRIPTION
This allows the user to specify custom output formatting for the results of a `club find` command. It also replaces the `--idonly` argument with `--quiet`, now that the ID only output can be achieved with `--format '%I'`.

Example usage:

~~~sh
$ club find -s foo -o bar -f '%I (%s) %t'
57 (#500000006 Backlog) Android, investigate CI emulator failing to boot

# Note that the `$` operator helps with newline and tab characters
$ club find -s foo -o bar -f $'%I\t%t'
57	#500000006 Backlog	Android, investigate CI emulator failing to boot
~~~