### PR TITLE
new:usr: Add sort option to club find

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This is a command line interface for [Clubhouse](https://app.clubhouse.io), focu
     -t, --text [name]       Stories with text in name, by regex
     -y, --type [name]       Stories of type, by regex
     -f, --format [template] Format each story output by template
+    -r, --sort [field]      Sort stories by field (accessor[:asc|desc][,next])
     -h, --help              output usage information
 ~~~
 
@@ -107,6 +108,10 @@ Templating variables:
 ~~~
 
 Note that the `$` string operator in bash is helpful in allowing `\t` (tab) and `\n` (newline) literals in the formatting string. Otherwise, you can actually just type a newline character.
+
+#### Story Output Sorting
+
+The default sorting for stories found is `state.position:asc,id:asc`, which translates to "sort by associated state position ascending, then by story id ascending within the same state."
 
 ### Story
 

--- a/src/bin/club-find
+++ b/src/bin/club-find
@@ -8,19 +8,35 @@ var program     = require('commander');
 
 program
     .description('Search through clubouse stories')
-    .option('-a, --archived', 'Include archived Stories')
-    .option('-c, --created [operator][date]', 'Stories created within criteria (oprateor is one of <|>|=)', '')
-    .option('-q, --quiet', 'Print only story output, no loading dialog', '')
-    .option('-l, --label [id|name]', 'Stories with label id/name, by regex', '')
-    .option('-o, --owner [name]', 'Stories with owner, by regex', '')
-    .option('-p, --project [id]', 'Stories in project', '')
-    .option('-s, --state [id|name]', 'Stories in workflow state id/name, by regex', '')
-    .option('-E, --epic [id|name]', 'Stories in epic id/name, by regex', '')
-    .option('-S, --save [name]', 'Save search configuration as workspace')
-    .option('-t, --text [name]', 'Stories with text in name, by regex', '')
-    .option('-u, --updated [operator][date]', 'Stories updated within criteria (oprateor is one of <|>|=)', '')
-    .option('-y, --type [name]', 'Stories of type, by regex', '')
-    .option('-f, --format [template]', 'Format each story output by template', '')
+    .option('-a, --archived',
+        'Include archived Stories')
+    .option('-c, --created [operator][date]',
+        'Stories created within criteria (oprateor is one of <|>|=)', '')
+    .option('-q, --quiet',
+        'Print only story output, no loading dialog', '')
+    .option('-l, --label [id|name]',
+        'Stories with label id/name, by regex', '')
+    .option('-o, --owner [name]',
+        'Stories with owner, by regex', '')
+    .option('-p, --project [id]',
+        'Stories in project', '')
+    .option('-s, --state [id|name]',
+        'Stories in workflow state id/name, by regex', '')
+    .option('-E, --epic [id|name]',
+        'Stories in epic id/name, by regex', '')
+    .option('-S, --save [name]',
+        'Save search configuration as workspace')
+    .option('-t, --text [name]',
+        'Stories with text in name, by regex', '')
+    .option('-u, --updated [operator][date]',
+        'Stories updated within criteria (oprateor is one of <|>|=)', '')
+    .option('-y, --type [name]',
+        'Stories of type, by regex', '')
+    .option('-r, --sort [field]',
+        'Sort stories by field (accessor[:asc|desc][,next])',
+        'state.position:asc,id:asc')
+    .option('-f, --format [template]',
+        'Format each story output by template', '')
     .parse(process.argv);
 spin.setSpinnerString(27);
 

--- a/src/bin/club-find
+++ b/src/bin/club-find
@@ -60,6 +60,7 @@ const main = async () => {
             owner:      program.owner    || undefined,
             project:    program.project  || undefined,
             state:      program.state    || undefined,
+            sort:       program.sort     || undefined,
             epic:       program.epic     || undefined,
             text:       program.text     || undefined,
             type:       program.type     || undefined,

--- a/src/lib/stories.js
+++ b/src/lib/stories.js
@@ -117,12 +117,11 @@ const sortStories = (program) => {
             if (ap > bp) {
                 if (direction > 0)
                     return -1;
-                return 1;
             } else {
                 if (direction < 0)
                     return -1;
-                return 1;
             }
+            return 1;
         }, 0);
     };
 };

--- a/src/lib/stories.js
+++ b/src/lib/stories.js
@@ -24,7 +24,8 @@ const listStories = async (program) => {
     return stories.map(filterStories(program, filteredProjects))
         .reduce((a, b) => {
             return a.concat(b);
-        }, []);
+        }, [])
+        .sort(sortStories(program));
 };
 const fetchStories = async (project) => {
     return client.listStories(project.id);
@@ -92,6 +93,39 @@ const filterStories = (program, projects) => { return (stories, index) => {
     });
     return filtered;
 };};
+const sortStories = (program) => {
+    const fields = program.sort
+        .split(',')
+        .map(s => {
+            return s.split(':')
+                .map(ss => ss.split('.'));
+        });
+    const pluck = (acc, val) => {
+        if (acc[val] === undefined)
+            return {};
+        return acc[val];
+    };
+    return (a, b) => {
+        return fields.reduce((acc, field) => {
+            if (acc !== 0)
+                return acc;
+            const ap = field[0].reduce(pluck, a);
+            const bp = field[0].reduce(pluck, b);
+            if (ap === bp)
+                return 0;
+            const direction = (field[1] || [''])[0].match(/des/i) ? 1 : -1;
+            if (ap > bp) {
+                if (direction > 0)
+                    return -1;
+                return 1;
+            } else {
+                if (direction < 0)
+                    return -1;
+                return 1;
+            }
+        }, 0);
+    };
+};
 
 const printStory = (program) => { return (story) => {
     const defaultFormat = `#%i %t


### PR DESCRIPTION
Resolves #27 

Example usage:

~~~sh
$ club find -t sales --sort estimate:asc,project.id:desc
~~~