### PR TITLE
new:usr: Allow workspace argument overrides

### DIFF
--- a/src/bin/club-find
+++ b/src/bin/club-find
@@ -6,7 +6,7 @@ const spin      = new Spinner('Finding... %s ');
 const log       = console.log;
 var program     = require('commander');
 
-program
+module.exports = program = program
     .description('Search through clubouse stories')
     .option('-a, --archived',
         'Include archived Stories')
@@ -36,8 +36,7 @@ program
         'Sort stories by field (accessor[:asc|desc][,next])',
         'state.position:asc,id:asc')
     .option('-f, --format [template]',
-        'Format each story output by template', '')
-    .parse(process.argv);
+        'Format each story output by template', '');
 spin.setSpinnerString(27);
 
 const main = async () => {
@@ -76,4 +75,7 @@ const main = async () => {
     return;
 };
 
-main();
+if (require.main === module) {
+    program.parse(process.argv);
+    main();
+}

--- a/src/bin/club-workspace
+++ b/src/bin/club-workspace
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-const { exec }     = require('child_process');
 const configure    = require('../lib/configure.js');
 const storyLib     = require('../lib/stories.js');
 const config       = configure.loadConfig();
@@ -51,36 +50,23 @@ const main = async () => {
         log('to create it.');
         return;
     }
-    const additionalArgs = program.rawArgs.slice(2)
-        .filter(a => a !== name)
-        .join(' ');
-    if (additionalArgs.length) {
-        if (!program.quiet){
-            log('Loading %s workspace (with alterations)', name);
-            log();
-        }
-        const args = toArgs(workspace) + ' ' + additionalArgs;
-        exec('club find ' + args, (err, stdout, stderr) => {
-            if (err || stderr) {
-                log('Error:');
-                log(err || stderr);
-                return;
-            }
-            log(stdout);
-        });
-        return;
-    }
+    const found = find.parse(process.argv);
+    const findOpts = found.options.map(o => o.name());
+    const additionalArgs = findOpts.reduce((acc, val) => {
+        acc[val] = found[val] || acc[val] || found[val];
+        return acc;
+    }, workspace);
     if (!program.quiet){
         log('Loading %s workspace', name);
         log();
     }
     let stories = [];
     try {
-        stories = await storyLib.listStories(workspace);
+        stories = await storyLib.listStories(additionalArgs);
     } catch (e) {
         log('Error fetching stories:', e);
     }
-    stories.map(storyLib.printStory(workspace));
+    stories.map(storyLib.printStory(additionalArgs));
 };
 main();
 

--- a/src/bin/club-workspace
+++ b/src/bin/club-workspace
@@ -3,6 +3,7 @@ const configure    = require('../lib/configure.js');
 const storyLib     = require('../lib/stories.js');
 const config       = configure.loadConfig();
 const log          = console.log;
+const find         = require('./club-find');
 var program        = require('commander');
 
 program
@@ -41,19 +42,19 @@ const main = async () => {
             log('Please run:');
             log('  club find [options] --save', name);
             log('to create it.');
-        } else {
-            if (!program.quiet){
-                log('Loading workspace %s:', name, toArgs(workspace));
-                log();
-            }
-            let stories = [];
-            try {
-                stories = await storyLib.listStories(workspace);
-            } catch (e) {
-                log('Error fetching stories:', e);
-            }
-            stories.map(storyLib.printStory(workspace));
+            return;
         }
+        if (!program.quiet){
+            log('Loading workspace %s:', name, toArgs(workspace));
+            log();
+        }
+        let stories = [];
+        try {
+            stories = await storyLib.listStories(workspace);
+        } catch (e) {
+            log('Error fetching stories:', e);
+        }
+        stories.map(storyLib.printStory(workspace));
     }
 };
 main();

--- a/src/bin/club-workspace
+++ b/src/bin/club-workspace
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+const { exec }     = require('child_process');
 const configure    = require('../lib/configure.js');
 const storyLib     = require('../lib/stories.js');
 const config       = configure.loadConfig();
@@ -18,44 +19,68 @@ const main = async () => {
     if (!config || !config.token) {
         log('Not installed yet.');
         log('Please run: club install');
+        return;
     } else if (!config.workspaces) {
         log('No workspace saved.');
         log('Please run:');
         log('  club find [options] --save');
         log('to create your first one.');
+        return;
     } else if (program.list) {
         log('Workspaces:');
         Object.keys(config.workspaces)
             .map(w => {
                 log(' ', w + ':', toArgs(config.workspaces[w]));
             });
+        return;
     } else if (program.unset) {
         const success = configure.removeWorkspace(program.unset);
         if (success) {
             log('Successfully removed %s workspace', program.unset);
+        } else {
+            log('Failed to remove %s workspace', program.unset);
         }
-    } else {
-        const name = program.name || program.args[0] || 'default';
-        const workspace = config.workspaces[name];
-        if (!workspace) {
-            log('No workspace saved with name', name);
-            log('Please run:');
-            log('  club find [options] --save', name);
-            log('to create it.');
-            return;
-        }
+        return;
+    }
+    const name = program.name || program.args[0] || 'default';
+    const workspace = config.workspaces[name];
+    if (!workspace) {
+        log('No workspace saved with name', name);
+        log('Please run:');
+        log('  club find [options] --save', name);
+        log('to create it.');
+        return;
+    }
+    const additionalArgs = program.rawArgs.slice(2)
+        .filter(a => a !== name)
+        .join(' ');
+    if (additionalArgs.length) {
         if (!program.quiet){
-            log('Loading workspace %s:', name, toArgs(workspace));
+            log('Loading %s workspace (with alterations)', name);
             log();
         }
-        let stories = [];
-        try {
-            stories = await storyLib.listStories(workspace);
-        } catch (e) {
-            log('Error fetching stories:', e);
-        }
-        stories.map(storyLib.printStory(workspace));
+        const args = toArgs(workspace) + ' ' + additionalArgs;
+        exec('club find ' + args, (err, stdout, stderr) => {
+            if (err || stderr) {
+                log('Error:');
+                log(err || stderr);
+                return;
+            }
+            log(stdout);
+        });
+        return;
     }
+    if (!program.quiet){
+        log('Loading %s workspace', name);
+        log();
+    }
+    let stories = [];
+    try {
+        stories = await storyLib.listStories(workspace);
+    } catch (e) {
+        log('Error fetching stories:', e);
+    }
+    stories.map(storyLib.printStory(workspace));
 };
 main();
 


### PR DESCRIPTION
Resolves #31 

Example usage:

~~~sh
$ club find -p foobar -f '%i' -S foo
$ club foo
# will invoke find with --project foobar --format '%i'
$ club foo --sort 'id:desc'
# will now invoke find with --project foobar  --format '%i' --sort 'id:desc'
$ club foo --sort 'id:desc' -f '%i %t'
# will now invoke find with --project foobar  --format '%i %t' --sort 'id:desc'
~~~

Caveats:
- This only works when `workspace` is invoked as the default command, due to argument checks