### PR TITLE
chg:usr: Infer story ID from git branch if none supplied

### DIFF
--- a/src/bin/club-story
+++ b/src/bin/club-story
@@ -118,7 +118,7 @@ const main = async () => {
     const hasUpdate = Object.keys(update).length > 0;
     debug('constructed story update');
     let gitID = [];
-    if (program.fromGit) {
+    if (program.fromGit || !program.args.length) {
         debug('fetching story ID from git');
         let branch = execSync('git branch').toString('utf-8');
         if (branch.match(/\*.*[0-9]+/)) {


### PR DESCRIPTION
Now, when calling `club story` while in a git branch that contains a story ID, you no longer need to pass the story ID explicitly!