### PR TITLE
chg:usr: Remove bolding from story custom formatted output

### DIFF
--- a/src/lib/stories.js
+++ b/src/lib/stories.js
@@ -206,9 +206,7 @@ const printFormattedStory = program => {
     `;
         const format = program.format || defaultFormat;
         const labels = story.labels.map(l => ` ${l.name} (#${l.id})`);
-        const owners = story.owners.map(
-            o => `${o.profile.name} (${o.profile.mention_name})`
-        );
+        const owners = story.owners.map(o => `${o.profile.name} (${o.profile.mention_name})`);
 
         log(
             format
@@ -220,9 +218,7 @@ const printFormattedStory = program => {
                 .replace(/%l/, labels.join(', ') || '_')
                 .replace(
                     /%E/,
-                    story.epic_id
-                        ? ` ${(story.epic || {}).name} (#${story.epic_id})`
-                        : '_'
+                    story.epic_id ? ` ${(story.epic || {}).name} (#${story.epic_id})` : '_'
                 )
                 .replace(/%p/, ` ${story.project.name} (#${story.project.id})`)
                 .replace(/%o/, owners.join(', ') || '_')

--- a/src/lib/stories.js
+++ b/src/lib/stories.js
@@ -205,11 +205,9 @@ const printFormattedStory = program => {
     \tArchived:\t%a
     `;
         const format = program.format || defaultFormat;
-        const labels = story.labels.map(l => {
-            return chalk.bold(`#${l.id}`) + ` ${l.name}`;
-        });
+        const labels = story.labels.map(l => ` ${l.name} (#${l.id})`);
         const owners = story.owners.map(
-            o => `${o.profile.name} (` + chalk.bold(`${o.profile.mention_name}`) + ')'
+            o => `${o.profile.name} (${o.profile.mention_name})`
         );
 
         log(
@@ -223,15 +221,12 @@ const printFormattedStory = program => {
                 .replace(
                     /%E/,
                     story.epic_id
-                        ? chalk.bold(`#${story.epic_id}`) + ` ${(story.epic || {}).name}`
+                        ? ` ${(story.epic || {}).name} (#${story.epic_id})`
                         : '_'
                 )
-                .replace(/%p/, chalk.bold(`#${story.project.id}`) + ` ${story.project.name}`)
+                .replace(/%p/, ` ${story.project.name} (#${story.project.id})`)
                 .replace(/%o/, owners.join(', ') || '_')
-                .replace(
-                    /%s/,
-                    chalk.bold(`#${story.workflow_state_id} `) + `${(story.state || {}).name}`
-                )
+                .replace(/%s/, `${(story.state || {}).name} (#${story.workflow_state_id})`)
                 .replace(/%u/, `https://app.clubhouse.io/story/${story.id}`)
                 .replace(/%c/, story.created_at)
                 .replace(/%u/, story.updated_at !== story.created_at ? story.updated_at : '_')


### PR DESCRIPTION
This changes custom-formatted output such that only the story ID is
bolded. This helps in scanning the output text (I think).

Before: (`#500000017`) is bolded
```
 ./src/bin/club default -f $'%i %t\n\t%s\n\t%o'
Loading default workspace ...

4719 Prevent loading animation on product similars when no similars exist
	#500000017 Scheduled
	_
```

After:
```
$ ./src/bin/club default -f $'%i %t\n\t%s\n\t%o'
Loading default workspace ...

4719 Prevent loading animation on product similars when no similars exist
	Scheduled (#500000017)
	_
```