### PR TITLE
fix propt import

### DIFF
--- a/src/bin/club-install.ts
+++ b/src/bin/club-install.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // @ts-ignore
-import prompt from 'prompt';
+import * as prompt from 'prompt';
 
 import configure from '../lib/configure';
 


### PR DESCRIPTION
By default, typescript assumes that when importing a module as `import module from 'module'` that everything in that module is contained inside a `.default` property.

Which leaves this error
```
/usr/lib/node_modules/clubhouse-cli/build/bin/club-install.js:27
    prompt_1.default.start({ message: 'clubhouse' });
```

Upon looking into the source code for `prompt`, it is obvious that such property does not exist

To fix this the import needs to be done as `import * as module from 'module'`