### PR TITLE
add:usr: Allow to open the story's epic, iteration and/or project.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Allow to open the story's epic, iteration and/or project.
+- Use xdg-open on non-macOS platform.
+- Add the Config interface and added workspaceName as a parameter.
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ The default sorting for stories found is `state.position:asc,position:asc`, whic
     -c, --comment [text]      Add comment to story
     -o, --owners [id|name]    Update owners of story, comma-separated
     -O, --open                Open story in browser
+    --oe, --open-epic         Open story's epic in browser
+    --oi, --open-iteration    Open story's iteration in browser
+    --op, --open-project      Open story's project in browser
     -q, --quiet               Print only story output, no loading dialog
     -t, --title [text]        Update title of story
     --task [text]             Create new task on story

--- a/src/bin/club-install.ts
+++ b/src/bin/club-install.ts
@@ -26,6 +26,11 @@ if (!extant || program.force) {
                 message: 'API Token -> https://app.clubhouse.io/xxxx/settings/account/api-tokens',
                 required: true,
             },
+            workspaceName: {
+                message:
+                    'Name of the Clubhouse Workspace (e.g.: xxxx) -> https://app.clubhouse.io/xxxx',
+                required: true,
+            },
         },
     };
     prompt.start({ message: 'clubhouse' });

--- a/src/bin/club-story.ts
+++ b/src/bin/club-story.ts
@@ -2,6 +2,7 @@
 import { execSync } from 'child_process';
 import * as commander from 'commander';
 
+import * as os from 'os';
 import fetch from 'node-fetch';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -59,6 +60,9 @@ const program = commander
     .option('--move-up [n]', 'Move story position upward by n stories')
     .option('-o, --owners [id|name]', 'Update owners of story, comma-separated', '')
     .option('-O, --open', 'Open story in browser')
+    .option('--oe, --open-epic', "Open story's epic in browser")
+    .option('--oi, --open-iteration', "Open story's iteration in browser")
+    .option('--op, --open-project', "Open story's project in browser")
     .option('-q, --quiet', 'Print only story output, no loading dialog', '')
     .option('-s, --state [id|name]', 'Update workflow state of story', '')
     .option('-t, --title [text]', 'Update title/name of story', '')
@@ -237,7 +241,10 @@ const main = async () => {
         if (!program.idonly) spin.stop(true);
         if (story) {
             printStory(story, entities);
-            if (program.open) execSync('open ' + storyLib.storyURL(story));
+            if (program.open) openURL(storyLib.storyURL(story));
+            if (program.openEpic) openURL(storyLib.buildURL('epic', story.epic_id));
+            if (program.openIteration) openURL(storyLib.buildURL('iteration', story.iteration_id));
+            if (program.openProject) openURL(storyLib.buildURL('project', story.project_id));
         }
         if (program.download) {
             downloadFiles(story);
@@ -258,6 +265,11 @@ const main = async () => {
         }
     });
     stopSpinner();
+};
+
+const openURL = (url: string) => {
+    const open = os.platform() === 'darwin' ? 'open' : 'xdg-open';
+    execSync(`${open} '${url}'`);
 };
 
 const stopSpinner = () => {

--- a/src/lib/configure.ts
+++ b/src/lib/configure.ts
@@ -5,7 +5,20 @@ import * as os from 'os';
 //TODO: Move to XDG_CONFIG
 const configFile = path.resolve(os.homedir(), '.clubhouse-cli', 'config.json');
 
-export const loadConfig = () => {
+export interface Config {
+    mentionName: string;
+
+    // Clubhouse workspace
+    // https://help.clubhouse.io/hc/en-us/sections/360000212786-Organizations-and-Workspaces.
+    workspaceName: string;
+
+    token: string;
+
+    // Object used by club workspace. Unrelated to the clubhouse concept of workspace.
+    workspaces: { [key: string]: object };
+}
+
+export const loadConfig: () => Config = () => {
     const envToken = process.env.CLUBHOUSE_API_TOKEN;
     if (fs.existsSync(configFile)) {
         try {
@@ -16,13 +29,13 @@ export const loadConfig = () => {
             return config;
         } catch (e) {
             console.error(e);
-            return false;
+            return {};
         }
     }
     if (envToken) {
         return { token: envToken };
     }
-    return false;
+    return {};
 };
 
 const saveConfig = (opt: any) => {

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -320,8 +320,20 @@ const printFormattedStory = (program: any) => {
     };
 };
 
-//TODO: Add workspace name in URL to avoid extra redirect.
-const storyURL = (story: Story) => `https://app.clubhouse.io/story/${story.id}`;
+const buildURL = (...segments: (string | number)[]): string => {
+    let finalSegments = ['https://app.clubhouse.io'];
+    if (config.workspaceName) {
+        finalSegments = finalSegments.concat(config.workspaceName);
+    } else {
+        log(
+            "Please add the 'workspaceName' to your configuration " +
+                "either manually or via 'club install'."
+        );
+    }
+    return finalSegments.concat(...segments.map(item => item.toString())).join('/');
+};
+
+const storyURL = (story: Story) => buildURL('story', story.id);
 
 const printDetailedStory = (story: StoryHydrated, entities: Entities = {}) => {
     const labels = story.labels.map(l => {
@@ -434,4 +446,5 @@ export default {
     findLabelNames,
     fileURL,
     storyURL,
+    buildURL,
 };


### PR DESCRIPTION
Unlike stories, those entities require the workspaceName to be
set in the URL. I therfore added workspaceName as a parameter in
the configuration.

While there I also added xdg-open on non-macOS platform. It will
most likely still be broken on Windows. /shrug

I used `--oe` for flags since commander will interpret somethign
like `-Oe` `-O and -e`.

Closes #74