### PR TITLE
add:usr:search: replace %self% with the user's mention name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- club search, replace `%self%` with the user's mention name.
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/bin/club-search.ts
+++ b/src/bin/club-search.ts
@@ -10,10 +10,11 @@ const log = console.log;
 
 export const program = commander
     .description(
-        `Search through clubhouse stories. Arguments (non-flag/options) will
-  be passed to Clubhouse story search API as search operators. Note that passing search
-  operators and options (e.g. --owner yourself) will use the options as extra filtering
-  in the client.
+        `Search through clubhouse stories. Arguments (non-flag/options) will be
+  passed to Clubhouse story search API as search operators. Passing '%self%' as
+  a search operator argument will be replaced ny your mention name. Note that
+  passing search operators and options (e.g. --owner yourself) will use the
+  options as extra filtering in the client.
 
   Refer to https://help.clubhouse.io/hc/en-us/articles/360000046646-Search-Operators
   for more details about search operators.`

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -103,7 +103,8 @@ const fetchStories = async (program: any, entities: Entities) => {
 };
 
 const searchStories = async (program: any) => {
-    let result = await client.searchStories(program.args.join(' '));
+    const query = program.args.join(' ').replace('%self%', config.mentionName);
+    let result = await client.searchStories(query);
     let stories = result.data;
     while (result.next) {
         result = await client.getResource(result.next);


### PR DESCRIPTION
This allows to share and reuse the same queries across different
users. E.g. `club search 'owner:%self% !is:done'` to list all
uncompleted tasks.

This is the equivalent to [`currentUser()`](https://confluence.atlassian.com/jirasoftwarecloud/advanced-searching-functions-reference-764478342.html#Advancedsearching-functionsreference-currentUsercurrentUser()) in JIRA. I asked
Clubhouse for this feature a long time ago.