### PR TITLE
chg:usr:config Respect XDG_CONFIG_HOME for the config location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- Respect XDG_CONFIG_HOME for the config location
 ### Deprecated
 ### Removed
 ### Fixed


### PR DESCRIPTION
It is generally recommended to use XDG_CONFIG_HOME instead of
poluting the HOME directory.

This commit moves existing configuration to the new location to
avoid errors with existing installations.