### PR TITLE
Get mentionName and urlSlug from api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Respect XDG_CONFIG_HOME for the config location
+### Changed
+- The `mentionName` and `urlSlug` (previously names `workspaceName`)
+  configuration now get set automatically.
+- The config is now only read once (unless noted otherwise)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-### Changed
+- Respect XDG_CONFIG_HOME for the config location
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/bin/club-install.ts
+++ b/src/bin/club-install.ts
@@ -3,47 +3,58 @@
 // @ts-ignore
 import * as prompt from 'prompt';
 
-import configure from '../lib/configure';
+import { Config, loadCachedConfig, updateConfig } from '../lib/configure';
+import * as commander from 'commander';
+import Clubhouse from 'clubhouse-lib';
 
-const extant = configure.loadConfig();
+const extant = loadCachedConfig();
 const log = console.log;
 
-import * as commander from 'commander';
 const program = commander
     .version(require('../../package').version)
     .description('Install access token and other settings for the Clubhouse API')
     .option('-f, --force', 'Force install/reinstall')
+    .option('-r, --refresh', 'Refresh the configuration with details from Clubhouse.')
     .parse(process.argv);
 
-if (!extant || program.force) {
-    const schema = {
-        properties: {
-            mentionName: {
-                message: 'Mention Name -> https://app.clubhouse.io/xxxx/settings/account/',
-                required: true,
-            },
-            token: {
-                message: 'API Token -> https://app.clubhouse.io/xxxx/settings/account/api-tokens',
-                required: true,
-            },
-            workspaceName: {
-                message:
-                    'Name of the Clubhouse Workspace (e.g.: xxxx) -> https://app.clubhouse.io/xxxx',
-                required: true,
-            },
-        },
+const enrichConfigWithMemberDetails = async (config: Config) => {
+    log('Fetching user/member details from Clubhouse...');
+    const member = await Clubhouse.create(config.token).getCurrentMember();
+    return {
+        mentionName: member.mention_name,
+        urlSlug: member.workspace2.url_slug,
+        ...config,
     };
-    prompt.start({ message: 'clubhouse' });
-    prompt.get(schema, (err: Error, result: any) => {
-        if (err) return log(err);
-        log('Saving config...');
-        const success = configure.updateConfig(result);
-        if (success) {
-            log('Saved config');
-        } else {
-            log('Error saving config');
-        }
-    });
-} else if (extant) {
-    log('A configuration/token is already saved. To override, re-run with --force');
-}
+};
+
+const main = async () => {
+    if (program.refresh) {
+        updateConfig(await enrichConfigWithMemberDetails(extant));
+    } else if (!extant.token || program.force) {
+        const schema = {
+            properties: {
+                token: {
+                    message:
+                        'API Token -> https://app.clubhouse.io/xxxx/settings/account/api-tokens',
+                    required: true,
+                },
+            },
+        };
+        prompt.start({ message: 'clubhouse' });
+        prompt.get(schema, async (err: Error, result: any) => {
+            if (err) return log(err);
+            const config = await enrichConfigWithMemberDetails(result);
+            log('Saving config...');
+            const success = updateConfig(config);
+            if (success) {
+                log('Saved config');
+            } else {
+                log('Error saving config');
+            }
+        });
+    } else if (extant.token) {
+        log('A configuration/token is already saved. To override, re-run with --force');
+    }
+};
+
+main();

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -4,11 +4,6 @@ import { loadConfig } from './configure';
 
 const config = loadConfig();
 
-if (!config) {
-    console.error('Please run install to configure API access');
-    process.exit(1);
-}
-
 const client = Clubhouse.create(config.token);
 
 export default client;

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -322,16 +322,11 @@ const printFormattedStory = (program: any) => {
 };
 
 const buildURL = (...segments: (string | number)[]): string => {
-    let finalSegments = ['https://app.clubhouse.io'];
-    if (config.workspaceName) {
-        finalSegments = finalSegments.concat(config.workspaceName);
-    } else {
-        log(
-            "Please add the 'workspaceName' to your configuration " +
-                "either manually or via 'club install'."
-        );
-    }
-    return finalSegments.concat(...segments.map(item => item.toString())).join('/');
+    return [
+        'https://app.clubhouse.io',
+        config.urlSlug,
+        ...segments.map(item => item.toString()),
+    ].join('/');
 };
 
 const storyURL = (story: Story) => buildURL('story', story.id);


### PR DESCRIPTION
- The `mentionName` and `urlSlug` (previously names `workspaceName`)
  configuration now get set automatically.
- The config is now only read once (unless noted otherwise).

Includes the previously closed https://github.com/andjosh/clubhouse-cli/pull/130