### PR TITLE
fix, search failing if there is a next url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix bug in /api/v3 which returns an invalid URL that could not be processed by
+  the client.
 ### Security
 
 ---

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -107,7 +107,10 @@ const searchStories = async (program: any) => {
     let result = await client.searchStories(query);
     let stories = result.data;
     while (result.next) {
-        result = await client.getResource(result.next);
+        // There is bug in Clubhouse API that returns /api/beta
+        // This can be removed once Clubhouse fixes the issue.
+        const sanitizedUrl = result.next.replace(/^\/api\/beta\//, '');
+        result = await client.getResource(sanitizedUrl);
         stories = stories.concat(result.data);
     }
     return stories;


### PR DESCRIPTION
There is a bug in the v3 API that returns the next URL which
contains the path to `/api/beta`.

Until Clubhouse fixes it we have to do it ourselves.

~~Depends on https://github.com/clubhouse/clubhouse-lib/pull/68~~