### PR TITLE
Feature: Allow restricting list of epics by milestone id

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Comment: This is a commend
     -a, --archived            List only epics including archived
     -c, --completed           List only epics that have been completed
     -d, --detailed            List more details for each epic
-    -M, --milestone [query]   List only epics with the given milestone ID
+    -M, --milestone [ID]   List only epics with the given milestone ID
     -t, --title [query]       List epics with name/title containing query
     -s, --started             List epics that have been started
     -h, --help                output usage information

--- a/README.md
+++ b/README.md
@@ -256,12 +256,13 @@ Comment: This is a commend
 
   Options:
 
-    -a, --archived       List only epics including archived
-    -c, --completed      List only epics that have been completed
-    -d, --detailed       List more details for each epic
-    -t, --title [query]  List epics with name/title containing query
-    -s, --started        List epics that have been started
-    -h, --help           output usage information
+    -a, --archived            List only epics including archived
+    -c, --completed           List only epics that have been completed
+    -d, --detailed            List more details for each epic
+    -M, --milestone [query]   List only epics with the given milestone ID
+    -t, --title [query]       List epics with name/title containing query
+    -s, --started             List epics that have been started
+    -h, --help                output usage information
 ~~~
 
 ### Workflows

--- a/src/bin/club-epics.ts
+++ b/src/bin/club-epics.ts
@@ -14,7 +14,7 @@ const program = commander
     .option('-a, --archived', 'List only epics including archived', '')
     .option('-c, --completed', 'List only epics that have been completed', '')
     .option('-d, --detailed', 'List more details for each epic', '')
-    .option('-M, --milestone [query]', 'List epics in milestone matching id', '')
+    .option('-M, --milestone [ID]', 'List epics in milestone matching id', '')
     .option('-t, --title [query]', 'List epics with name/title containing query', '')
     .option('-s, --started', 'List epics that have been started', '')
     .parse(process.argv);
@@ -24,12 +24,11 @@ const main = async () => {
     const epics = await client.listEpics();
     spin.stop(true);
     const textMatch = new RegExp(program.title, 'i');
-    const milestoneMatch = new RegExp(program.milestone, 'i');
     epics
         .filter((epic: Epic) => {
             return (
                 !!`${epic.name} ${epic.name}`.match(textMatch) &&
-                !!(program.milestone && `${epic.milestone_id}`.match(milestoneMatch))
+                !!(program.milestone && epic.milestone_id == program.milestone )
             );
         })
         .map(printItem);

--- a/src/bin/club-epics.ts
+++ b/src/bin/club-epics.ts
@@ -28,7 +28,7 @@ const main = async () => {
         .filter((epic: Epic) => {
             return (
                 !!`${epic.name} ${epic.name}`.match(textMatch) &&
-                !!(program.milestone && epic.milestone_id == program.milestone )
+                !!(program.milestone ? epic.milestone_id == program.milestone : true)
             );
         })
         .map(printItem);


### PR DESCRIPTION
I want to be able to list all the epics within a milestone. 

This PR adds an option to the `epics` command to allow the user to specify a milestone ID by which to limit the list of epics, i.e.:

```bash 
$ club epics -M 12345     # or 
$ club epics --milestone 12345
``` 

~I'll add some tests, but is there anything else I've forgotten?~ I saw this in `CONTRIBUTING` when creating my PR, but I just realised there are no other tests. Is this still a requirement? 

Feedback gratefully received. 