### PR TITLE
fix: checkout existing branches on —git-branch

### DIFF
--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -424,7 +424,7 @@ const checkoutStoryBranch = (story: StoryHydrated, prefix: string = '') => {
         .replace(/-$/, '');
     const branch = `${prefix}${slug}`;
     debug('checking out git branch: ' + branch);
-    execSync('git checkout -b ' + branch);
+    execSync(`git checkout ${branch} 2> /dev/null || git checkout -b ${branch}`);
 };
 
 // @ts-ignore


### PR DESCRIPTION
Silently attempt to switch to an existing branch for a given story before creating a new one. Fixes repeated `--git-branch` on a single story.