### PR TITLE
Formatter to print git integration branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Templating variables:
 %updated Print story updated timestamp (if different from created)
 %j       Print full story as formatted JSON
 %gb      Print Git integration branch name
+%gbs     Pring Git integration branch short name
 ~~~
 
 Note that the `$` string operator in bash is helpful in allowing `\t` (tab) and `\n` (newline) literals in the formatting string. Otherwise, you can actually just type a newline character.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Templating variables:
 %c       Print story creation timestamp
 %updated Print story updated timestamp (if different from created)
 %j       Print full story as formatted JSON
+%gb      Print Git integration branch name
 ~~~
 
 Note that the `$` string operator in bash is helpful in allowing `\t` (tab) and `\n` (newline) literals in the formatting string. Otherwise, you can actually just type a newline character.

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -420,7 +420,7 @@ const buildStoryBranch = (story: StoryHydrated, prefix: string = '') => {
     prefix = prefix || `${config.mentionName}/ch${story.id}/${story.story_type}-`;
     let slug = story.name
         .toLowerCase()
-        .replace(/\s/g, '-')
+        .replace(/\W/g, '-')
         .replace(/[^a-z0-9-]/g, '')
         .slice(0, 30)
         .replace(/-$/, '');

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -319,7 +319,8 @@ const printFormattedStory = (program: any) => {
                 )
                 .replace(/%u/, url)
                 .replace(/%a/, `${story.archived}`)
-                .replace(/%gb/, `${buildStoryBranch(story)}`)
+                .replace(/%gbf/, `${buildStoryBranch(story)}`)
+                .replace(/%gbs/, `${buildStoryBranch(story, `${config.mentionName}/ch${story.id}/`)}`)
         );
         return story;
     };

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -319,8 +319,8 @@ const printFormattedStory = (program: any) => {
                 )
                 .replace(/%u/, url)
                 .replace(/%a/, `${story.archived}`)
-                .replace(/%gbf/, `${buildStoryBranch(story)}`)
                 .replace(/%gbs/, `${buildStoryBranch(story, `${config.mentionName}/ch${story.id}/`)}`)
+                .replace(/%gb/, `${buildStoryBranch(story)}`)
         );
         return story;
     };

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -319,6 +319,7 @@ const printFormattedStory = (program: any) => {
                 )
                 .replace(/%u/, url)
                 .replace(/%a/, `${story.archived}`)
+                .replace(/%gb/, `${buildStoryBranch(story)}`)
         );
         return story;
     };
@@ -414,7 +415,7 @@ const parseDateComparator: (arg: string) => (date: string) => boolean = arg => {
     };
 };
 
-const checkoutStoryBranch = (story: StoryHydrated, prefix: string = '') => {
+const buildStoryBranch = (story: StoryHydrated, prefix: string = '') => {
     prefix = prefix || `${config.mentionName}/ch${story.id}/${story.story_type}-`;
     let slug = story.name
         .toLowerCase()
@@ -422,7 +423,11 @@ const checkoutStoryBranch = (story: StoryHydrated, prefix: string = '') => {
         .replace(/[^a-z0-9-]/g, '')
         .slice(0, 30)
         .replace(/-$/, '');
-    const branch = `${prefix}${slug}`;
+    return `${prefix}${slug}`;
+}
+
+const checkoutStoryBranch = (story: StoryHydrated, prefix: string = '') => {
+    const branch = buildStoryBranch(story, prefix);
     debug('checking out git branch: ' + branch);
     execSync(`git checkout ${branch} 2> /dev/null || git checkout -b ${branch}`);
 };


### PR DESCRIPTION
Adds support for printing the Git integration branch name via the `-f` option for stories. This is useful for searching Github for associated PRs via the [gh cli tool](https://github.com/cli/cli)