### PR TITLE
add:dev: add prepublish hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add `prepublish` hook to ensure the project is built before it's being published.
 ### Changed
 ### Deprecated
 ### Removed

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
+    "prepublish": "npm run clean && npm run build",
+    "clean": "rm -rf build",
     "start": "node -r source-map-support/register build/bin/club.js",
     "test": "npm run test:format",
     "test:format": "prettier --list-different src/**/*.ts",


### PR DESCRIPTION
This ensures the project is built before it's being published.