### PR TITLE
initial support for teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Show team when showing stories.
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Templating variables:
 %id      Print ID of story
 %t       Print title/name of story
 %a       Print archived status of story
+%T       Print the team name
 %o       Print owners of story
 %l       Print labels on story
 %u       Print URL of story


### PR DESCRIPTION
Show only the team when viewing stories for now.

Does not include a story-team command or the ability to search (via filters) stories or assign a team to a story.