### PR TITLE
fix: use storyURL helper in search command to include workspace slug

### DIFF
--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -332,7 +332,7 @@ const printFormattedStory = (program: any) => {
         const owners = story.owners.map(
             (o: Member) => `${o.profile.name} (${o.profile.mention_name})`
         );
-        const url = `https://app.shortcut.com/story/${story.id}`;
+        const url = storyURL(story);
         const project = story.project ? `${story.project.name} (#${story.project.id})` : 'None';
         log(
             format


### PR DESCRIPTION
## Description
This PR fixes a bug in the `short search` command where the generated URLs for stories were missing the workspace slug (e.g., `https://app.shortcut.com/story/123` instead of `https://app.shortcut.com/my-workspace/story/123`).  Since the workspace was missing from the URL, clicking on the links from story search in the cli would just load up a blank broken page.
The fix involves updating `printFormattedStory` in `src/lib/stories.ts` to use the existing `storyURL` helper function, which correctly constructs the URL using the configured workspace slug.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
## How Has This Been Verified?
- **Manual Verification**: I ran the `short search` command locally against a real workspace configuration and verified that the output URLs now correctly include the workspace slug.

```bash
  ./build/bin/short.js search "playwright team:My-Team is:unstarted"
```

  This was in the output: `https://app.shortcut.com/my-workspace/story/123`
- **Build**: Verified that `npm run build` completes successfully.
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings