### PR TITLE
feat: add --team option to update story team/group

### DIFF
--- a/src/bin/short-story.ts
+++ b/src/bin/short-story.ts
@@ -65,6 +65,7 @@ const program = commander
     .option('-q, --quiet', 'Print only story output, no loading dialog', '')
     .option('-s, --state [id|name]', 'Update workflow state of story', '')
     .option('-t, --title [text]', 'Update title/name of story', '')
+    .option('-T, --team [id|name]', 'Update team/group of story', '')
     .option('--task [text]', 'Create new task on story')
     .option('--task-complete [text]', 'Toggle completion of task on story matching text')
     .option('-y, --type [name]', 'Update type of story', '')
@@ -112,6 +113,9 @@ const main = async () => {
     }
     if (program.label) {
         update.labels = storyLib.findLabelNames(entities, program.label);
+    }
+    if (program.team) {
+        update.group_id = (storyLib.findGroup(entities, program.team) || ({} as any)).id;
     }
     const hasPositionUpdate =
         program.moveAfter !== undefined ||


### PR DESCRIPTION
# Add --team option to update story team/group

## Summary

This PR adds a new `-T, --team [id|name]` option to the `short story` command, allowing users to update the team (group) associated with a story from the CLI.

## Motivation

Previously, there was no way to update a story's team assignment through the CLI. Users had to use the Shortcut web UI to change team assignments. This PR fills that gap by adding team update functionality that works consistently with other story update options like `--epic`, `--iteration`, and `--owners`.

## Changes

- Added `-T, --team [id|name]` option to the story command
- Implemented team lookup using the existing `findGroup` function from the stories library
- Updates the `group_id` field in the story update request

## How to Test

### Prerequisites
1. Build the project: `npm run build`
2. Ensure you have a configured Shortcut API token: `short install`

### Test Cases

#### 1. View current team assignment
```bash
node build/bin/short-story.js <story-id>
```
Look for the `Team:` field in the output.

#### 2. Update team by name
```bash
node build/bin/short-story.js <story-id> -T "Engineering"
```
Then verify the update:
```bash
node build/bin/short-story.js <story-id>
```
The `Team:` field should now show your team name.

#### 3. Update team by ID
```bash
node build/bin/short-story.js <story-id> -T <team-uuid>
```

#### 4. Test with partial name matching (regex)
Since the implementation uses regex matching (like other options), you can use partial names:
```bash
node build/bin/short-story.js <story-id> -T "Eng"
```
This will match any team with "Eng" in the name (e.g., "Engineering", "Engine Team").

#### 5. Test help text
```bash
node build/bin/short-story.js --help
```
Verify the `-T, --team [id|name]` option is listed.

### Example Output

Before update:
```
#12345 Example Story Title
...
Team:      _
...
```

After running `short story 12345 -T Engineering`:
```
#12345 Example Story Title
...
Team:      Engineering
...
Team:   #xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx Engineering
...
```

## Implementation Details

The implementation follows the same pattern as other update options:
1. Checks if `program.team` is set
2. Uses `storyLib.findGroup(entities, program.team)` to find the group by ID or name
3. Sets `update.group_id` to the found group's ID
4. Includes the update in the story update API call

## Related

- Shortcut API Documentation: [Update Story](https://developer.shortcut.com/api/rest/v3#Update-Story)
- The `UpdateStory` interface already supported `group_id`, this PR just exposes it via the CLI

## Checklist

- [x] Code follows existing patterns and style
- [x] Option follows naming conventions (short flag `-T`, long flag `--team`)
- [x] Functionality tested manually with real Shortcut data
- [x] Help text updated with new option
- [ ] Tests added (Note: Project currently has no test suite)

