### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
             contents: read
             id-token: write # Required for OIDC
         steps:
-            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: 'npm'
                   registry-url: 'https://registry.npmjs.org'
             # Ensure npm 11.5.1 or later is installed

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,11 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - name: Use Node.js
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: 'npm'
             - name: Install dependencies
               run: npm ci
@@ -24,11 +24,11 @@ jobs:
     format-check:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - name: Use Node.js
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: 'npm'
             - name: Install dependencies
               run: npm ci
@@ -38,11 +38,11 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - name: Use Node.js
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: 'npm'
             - name: Install dependencies
               run: npm ci
@@ -52,11 +52,11 @@ jobs:
     type-check:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - name: Use Node.js
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: 'npm'
             - name: Install dependencies
               run: npm ci


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest versions of key actions and upgrades the Node.js version used in CI jobs. These changes help ensure better security, compatibility, and access to the latest features and bug fixes.

**Workflow dependency updates:**

* Upgraded `actions/checkout` from v5.0.0 to v5.0.1 in both `.github/workflows/publish.yml` and `.github/workflows/tests.yml` for all jobs.
* Upgraded `actions/setup-node` from v4.4.0 to v6.0.0 in both workflow files for all jobs.
**Node.js version upgrade:**

* Changed the Node.js version used in all jobs from 22 to 24, ensuring the workflows use the latest LTS version.