### PR TITLE
Update `@shortcut/client` from `2.3.1` to `3.1.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@shortcut-cli/shortcut-cli",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shortcut-cli/shortcut-cli",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
-        "@shortcut/client": "^2.3.1",
+        "@shortcut/client": "^3.1.0",
         "chalk": "^2.2.0",
         "cli-spinner": "^0.2.10",
         "commander": "^2.12.0",
@@ -780,9 +780,9 @@
       "license": "MIT"
     },
     "node_modules/@shortcut/client": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@shortcut/client/-/client-2.3.1.tgz",
-      "integrity": "sha512-zR4Q+eOb2xuGlTvVVXZHiTQva5JzhbGifV0sZhe3+G+F2L/tngZQ9HAi4qfRSoKQc8Ks+Ws1CuVylB4EVjKOug==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@shortcut/client/-/client-3.1.0.tgz",
+      "integrity": "sha512-+ywXLviDhMvfei5Gk7kvKPEYoC6sCrsFIXUbd6Bp+TYC7QbkK94XlxyFj33jMkGp6zuq6Rb8SaTnRN5xEIC5cQ==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.9.0"
@@ -5836,9 +5836,9 @@
       "dev": true
     },
     "@shortcut/client": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@shortcut/client/-/client-2.3.1.tgz",
-      "integrity": "sha512-zR4Q+eOb2xuGlTvVVXZHiTQva5JzhbGifV0sZhe3+G+F2L/tngZQ9HAi4qfRSoKQc8Ks+Ws1CuVylB4EVjKOug==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@shortcut/client/-/client-3.1.0.tgz",
+      "integrity": "sha512-+ywXLviDhMvfei5Gk7kvKPEYoC6sCrsFIXUbd6Bp+TYC7QbkK94XlxyFj33jMkGp6zuq6Rb8SaTnRN5xEIC5cQ==",
       "requires": {
         "axios": "^1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/shortcut-cli/shortcut-cli",
   "dependencies": {
-    "@shortcut/client": "^2.3.1",
+    "@shortcut/client": "^3.1.0",
     "chalk": "^2.2.0",
     "cli-spinner": "^0.2.10",
     "commander": "^2.12.0",


### PR DESCRIPTION
[📚 Release notes](https://github.com/useshortcut/shortcut-client-js/releases).