### PR TITLE
Implement Docs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@ This is a community-driven command line interface for [Shortcut](https://shortcu
 
 ## Table of Contents
 
--   [Usage & Commands](#usage)
-    -   [Install](#install)
-    -   [Search](#search)
-    -   [Story](#story)
-    -   [Story Creation](#story-creation)
-    -   [Workspace](#workspace)
-    -   [Members](#members)
-    -   [Epics](#epics)
-    -   [Workflows](#workflows)
-    -   [Projects](#projects)
-    -   [API](#api)
--   [Development](#development)
--   [Acknowledgments](#acknowledgments)
+- [Usage & Commands](#usage)
+    - [Install](#install)
+    - [Search](#search)
+    - [Story](#story)
+    - [Story Creation](#story-creation)
+    - [Workspace](#workspace)
+    - [Members](#members)
+    - [Epics](#epics)
+    - [Docs](#docs)
+    - [Workflows](#workflows)
+    - [Projects](#projects)
+    - [API](#api)
+- [Development](#development)
+- [Acknowledgments](#acknowledgments)
 
 ## Usage
 
@@ -54,8 +55,8 @@ SHORTCUT_API_TOKEN=foobar short story 3300
 
 To skip `short install` entirely, set the additional environment variables used for URL and mention-name substitutions:
 
--   `SHORTCUT_URL_SLUG` – your workspace slug, e.g. `acme-co`
--   `SHORTCUT_MENTION_NAME` – your personal mention name used in branches, e.g. `mike`
+- `SHORTCUT_URL_SLUG` – your workspace slug, e.g. `acme-co`
+- `SHORTCUT_MENTION_NAME` – your personal mention name used in branches, e.g. `mike`
 
 With these env vars in place you can run commands directly:
 
@@ -87,6 +88,8 @@ short story 3300
     create          create a story
     workflows       list workflows and their states
     epics           list epics and their states
+    docs            list and search docs
+    doc             view, create, update, or delete a doc
     projects        list or search projects
     workspace       list stories matching saved workspace query
     api             make a request to the Shortcut API
@@ -320,6 +323,29 @@ Comment: This is a comment
     -h, --help                output usage information
 ```
 
+#### Epic Creation
+
+```
+  Usage: short epic create [options]
+
+  create a new epic
+
+
+  Options:
+
+    -n, --name [text]          Set name of epic, required
+    -d, --description [text]   Set description of epic
+    -s, --state [name]         Set state of epic (to do, in progress, done)
+    --deadline [date]          Set deadline for epic (YYYY-MM-DD)
+    --planned-start [date]     Set planned start date (YYYY-MM-DD)
+    -o, --owners [id|name]     Set owners of epic, comma-separated
+    -T, --team [id|name]       Set team of epic
+    -l, --label [id|name]      Set labels of epic, comma-separated
+    -I, --idonly               Print only ID of epic result
+    -O, --open                 Open epic in browser
+    -h, --help                 output usage information
+```
+
 #### Epic Output Formatting
 
 Templating variables:
@@ -338,6 +364,97 @@ Templating variables:
 %a       Print archived status of epic
 %st      Print started status of epic
 %co      Print completed status of epic
+```
+
+### Docs
+
+```
+  Usage: short docs [options]
+
+  List and search Shortcut Docs. By default, lists all docs you have access to.
+  Use --title to search docs by title.
+
+
+  Options:
+
+    -a, --archived      Search for archived docs (requires --title)
+    -m, --mine          Search for docs created by me (requires --title)
+    -f, --following     Search for docs I am following (requires --title)
+    -t, --title [text]  Search docs by title (required for search filters)
+    -q, --quiet         Print only doc output, no loading dialog
+    -I, --idonly        Print only IDs of doc results
+    -h, --help          output usage information
+```
+
+#### Doc View, Create, Update, Delete
+
+```
+  Usage: short doc [command] [options]
+
+  view, create, or update a doc
+
+
+  Commands:
+
+    view [options] <id>    view a doc by ID
+    create [options]       create a new doc
+    update [options] <id>  update an existing doc
+    delete [options] <id>  delete a doc
+```
+
+View a doc:
+
+```
+  Usage: short doc view <id> [options]
+
+  Options:
+
+    --html       Include HTML content in output
+    -O, --open   Open doc in browser
+    -q, --quiet  Print only doc content, no metadata
+    -h, --help   output usage information
+```
+
+You can also view a doc directly by ID: `short doc <uuid>`
+
+Create a doc:
+
+```
+  Usage: short doc create [options]
+
+  Options:
+
+    -t, --title <text>    Set title of doc (required)
+    -c, --content <text>  Set content of doc (required)
+    --markdown            Treat content as markdown (default is HTML)
+    -I, --idonly          Print only ID of doc result
+    -O, --open            Open doc in browser
+    -h, --help            output usage information
+```
+
+Update a doc:
+
+```
+  Usage: short doc update <id> [options]
+
+  Options:
+
+    -t, --title <text>    Update title of doc
+    -c, --content <text>  Update content of doc
+    --markdown            Treat content as markdown (default is HTML)
+    -O, --open            Open doc in browser
+    -h, --help            output usage information
+```
+
+Delete a doc:
+
+```
+  Usage: short doc delete <id> [options]
+
+  Options:
+
+    --confirm   Confirm deletion (required)
+    -h, --help  output usage information
 ```
 
 ### Workflows
@@ -409,11 +526,11 @@ npm start -- story 1234
 
 ## Acknowledgments
 
--   [Repository for this code](https://github.com/shortcut-cli/shortcut-cli)
--   [NPM registry for this code](https://www.npmjs.com/package/@shortcut-cli/shortcut-cli)
--   [Shortcut API](https://shortcut.com/api/rest/v3)
--   Official [@shortcut/client](https://github.com/useshortcut/shortcut-client-js)
--   [joshbeckman](https://github.com/joshbeckman), [j-martin](https://github.com/j-martin), [joshmfrankel](https://github.com/joshmfrankel), and [ohe](https://github.com/ohe) who created and contributed to this project
+- [Repository for this code](https://github.com/shortcut-cli/shortcut-cli)
+- [NPM registry for this code](https://www.npmjs.com/package/@shortcut-cli/shortcut-cli)
+- [Shortcut API](https://shortcut.com/api/rest/v3)
+- Official [@shortcut/client](https://github.com/useshortcut/shortcut-client-js)
+- [joshbeckman](https://github.com/joshbeckman), [j-martin](https://github.com/j-martin), [joshmfrankel](https://github.com/joshmfrankel), and [ohe](https://github.com/ohe) who created and contributed to this project
 
 ## Contributors
 

--- a/src/bin/short-doc.ts
+++ b/src/bin/short-doc.ts
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+import { exec } from 'child_process';
+import os from 'os';
+
+import type { Doc, CreateDoc, UpdateDoc } from '@shortcut/client';
+import commander from 'commander';
+import chalk from 'chalk';
+
+import client from '../lib/client';
+import spinner from '../lib/spinner';
+
+const spin = spinner();
+const log = console.log;
+
+const program = commander.usage('[command] [options]').description('view, create, or update a doc');
+
+program
+    .command('view <id>')
+    .description('view a doc by ID')
+    .option('--html', 'Include HTML content in output')
+    .option('-O, --open', 'Open doc in browser')
+    .option('-q, --quiet', 'Print only doc content, no metadata')
+    .action(viewDoc);
+
+program
+    .command('create')
+    .description('create a new doc')
+    .option('-t, --title <text>', 'Set title of doc (required)')
+    .option('-c, --content <text>', 'Set content of doc (required)')
+    .option('--markdown', 'Treat content as markdown (default is HTML)')
+    .option('-I, --idonly', 'Print only ID of doc result')
+    .option('-O, --open', 'Open doc in browser')
+    .action(createDoc);
+
+program
+    .command('update <id>')
+    .description('update an existing doc')
+    .option('-t, --title <text>', 'Update title of doc')
+    .option('-c, --content <text>', 'Update content of doc')
+    .option('--markdown', 'Treat content as markdown (default is HTML)')
+    .option('-O, --open', 'Open doc in browser')
+    .action(updateDoc);
+
+program
+    .command('delete <id>')
+    .description('delete a doc')
+    .option('--confirm', 'Confirm deletion without prompting')
+    .action(deleteDoc);
+
+// If first argument looks like a UUID, treat it as view command
+const args = process.argv.slice(2);
+if (args.length > 0 && isUUID(args[0])) {
+    // Insert 'view' command before the ID
+    process.argv.splice(2, 0, 'view');
+}
+
+program.parse(process.argv);
+
+// Show help and exit with error if no command provided
+if (args.length === 0) {
+    program.outputHelp();
+    process.exit(1);
+} else if (args.length > 0 && !isUUID(args[0])) {
+    const validCommands = ['view', 'create', 'update', 'delete'];
+    if (!validCommands.includes(args[0]) && !args[0].startsWith('-')) {
+        console.error(`Error: Unknown command or invalid doc ID: ${args[0]}`);
+        console.error('Run "short doc --help" for usage information.');
+        process.exit(1);
+    }
+}
+
+function isUUID(str: string): boolean {
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    return uuidRegex.test(str);
+}
+
+async function viewDoc(id: string, options: any) {
+    if (!options.quiet) spin.start();
+
+    let doc: Doc;
+    try {
+        const params: { content_format?: 'markdown' | 'html' } = {};
+        if (options.html) {
+            params.content_format = 'html';
+        }
+        doc = await client.getDoc(id, params).then((r) => r.data);
+    } catch (e: any) {
+        if (!options.quiet) spin.stop(true);
+        log('Error fetching doc:', e.message || e);
+        process.exit(1);
+    }
+
+    if (!options.quiet) spin.stop(true);
+
+    if (options.quiet) {
+        // Just print the content
+        log(doc.content_markdown || doc.content_html || '(No content)');
+    } else {
+        printDoc(doc, options.html);
+    }
+
+    if (options.open) {
+        openURL(doc.app_url);
+    }
+}
+
+async function createDoc(options: any) {
+    if (!options.title) {
+        log('Must provide --title');
+        process.exit(1);
+    }
+    if (!options.content) {
+        log('Must provide --content');
+        process.exit(1);
+    }
+
+    if (!options.idonly) spin.start();
+
+    const docData: CreateDoc = {
+        title: options.title,
+        content: options.content,
+        content_format: options.markdown ? 'markdown' : 'html',
+    };
+
+    let doc: Doc;
+    try {
+        const result = await client.createDoc(docData);
+        // createDoc returns DocSlim, so we need to fetch the full doc
+        doc = await client.getDoc(result.data.id).then((r) => r.data);
+    } catch (e: any) {
+        if (!options.idonly) spin.stop(true);
+        log('Error creating doc:', e.message || e);
+        process.exit(1);
+    }
+
+    if (!options.idonly) spin.stop(true);
+
+    if (options.idonly) {
+        log(doc.id);
+    } else {
+        log(chalk.green('Doc created successfully!'));
+        printDoc(doc);
+    }
+
+    if (options.open) {
+        openURL(doc.app_url);
+    }
+}
+
+async function updateDoc(id: string, options: any) {
+    if (!options.title && !options.content) {
+        log('Must provide --title and/or --content to update');
+        process.exit(1);
+    }
+
+    spin.start();
+
+    const docData: UpdateDoc = {};
+    if (options.title) {
+        docData.title = options.title;
+    }
+    if (options.content) {
+        docData.content = options.content;
+        docData.content_format = options.markdown ? 'markdown' : 'html';
+    }
+
+    let doc: Doc;
+    try {
+        doc = await client.updateDoc(id, docData).then((r) => r.data);
+    } catch (e: any) {
+        spin.stop(true);
+        log('Error updating doc:', e.message || e);
+        process.exit(1);
+    }
+
+    spin.stop(true);
+
+    log(chalk.green('Doc updated successfully!'));
+    printDoc(doc);
+
+    if (options.open) {
+        openURL(doc.app_url);
+    }
+}
+
+async function deleteDoc(id: string, options: any) {
+    if (!options.confirm) {
+        log('Deletion requires --confirm flag');
+        log('Usage: short doc delete <id> --confirm');
+        process.exit(1);
+    }
+
+    spin.start();
+
+    try {
+        await client.deleteDoc(id, {});
+    } catch (e: any) {
+        spin.stop(true);
+        log('Error deleting doc:', e.message || e);
+        process.exit(1);
+    }
+
+    spin.stop(true);
+
+    log(chalk.green(`Doc ${id} deleted successfully.`));
+}
+
+function printDoc(doc: Doc, includeHtml = false) {
+    log(chalk.blue.bold(doc.title || '(Untitled)'));
+    log(chalk.bold('ID:') + `       ${doc.id}`);
+    log(chalk.bold('URL:') + `      ${doc.app_url}`);
+    log(chalk.bold('Created:') + `  ${doc.created_at}`);
+    if (doc.created_at !== doc.updated_at) {
+        log(chalk.bold('Updated:') + `  ${doc.updated_at}`);
+    }
+    if (doc.archived) {
+        log(chalk.bold('Archived:') + ` ${doc.archived}`);
+    }
+    log();
+    if (doc.content_markdown) {
+        log(chalk.bold('Content (Markdown):'));
+        log(doc.content_markdown);
+    }
+    if (includeHtml && doc.content_html) {
+        log();
+        log(chalk.bold('Content (HTML):'));
+        log(doc.content_html);
+    }
+}
+
+function openURL(url: string) {
+    const open = os.platform() === 'darwin' ? 'open' : 'xdg-open';
+    exec(`${open} '${url}'`);
+}

--- a/src/bin/short-docs.ts
+++ b/src/bin/short-docs.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import commander from 'commander';
+import type { DocSlim } from '@shortcut/client';
+
+import client from '../lib/client';
+import spinner from '../lib/spinner';
+
+const spin = spinner('Loading docs... %s ');
+const log = console.log;
+
+const program = commander
+    .description(
+        `List and search Shortcut Docs. By default, lists all docs you have access to.
+  Use --title to search docs by title.`
+    )
+    .usage('[options]')
+    .option('-a, --archived', 'Search for archived docs (requires --title)')
+    .option('-m, --mine', 'Search for docs created by me (requires --title)')
+    .option('-f, --following', 'Search for docs I am following (requires --title)')
+    .option('-t, --title [text]', 'Search docs by title (required for search filters)')
+    .option('-q, --quiet', 'Print only doc output, no loading dialog')
+    .option('-I, --idonly', 'Print only IDs of doc results')
+    .parse(process.argv);
+
+const main = async () => {
+    if (!program.quiet) spin.start();
+
+    let docs: DocSlim[] = [];
+
+    try {
+        // Use search endpoint if title is provided
+        if (program.title) {
+            const searchParams: {
+                title: string;
+                archived?: boolean;
+                created_by_me?: boolean;
+                followed_by_me?: boolean;
+            } = {
+                title: program.title,
+            };
+
+            if (program.archived !== undefined) {
+                searchParams.archived = !!program.archived;
+            }
+            if (program.mine) {
+                searchParams.created_by_me = true;
+            }
+            if (program.following) {
+                searchParams.followed_by_me = true;
+            }
+
+            const result = await client.searchDocuments(searchParams);
+            docs = result.data.data;
+        } else {
+            // Warn if search filters are used without title
+            if (program.archived || program.mine || program.following) {
+                if (!program.quiet) spin.stop(true);
+                log('Note: --archived, --mine, and --following require --title for searching.');
+                log('Listing all docs instead...');
+                if (!program.quiet) spin.start();
+            }
+            // List all docs
+            const result = await client.listDocs();
+            docs = result.data;
+        }
+    } catch (e: any) {
+        if (!program.quiet) spin.stop(true);
+        log('Error fetching docs:', e.message || e);
+        process.exit(1);
+    }
+
+    if (!program.quiet) spin.stop(true);
+
+    if (docs.length === 0) {
+        log('No docs found.');
+        return;
+    }
+
+    docs.forEach((doc) => printDoc(doc));
+};
+
+const printDoc = (doc: DocSlim) => {
+    if (program.idonly) {
+        return log(doc.id);
+    }
+    log(`${doc.id} ${doc.title || '(Untitled)'}`);
+    log(`\tURL: ${doc.app_url}`);
+};
+
+main();

--- a/src/bin/short.ts
+++ b/src/bin/short.ts
@@ -23,6 +23,9 @@ commander
     .command('epics [options]', 'list epics and their states')
     .alias('e')
     .command('epic [command] [options]', 'create or view an epic')
+    .command('docs [options]', 'list and search docs')
+    .alias('d')
+    .command('doc [command] [options]', 'view, create, or update a doc')
     .command('projects [options]', 'list projects and their states')
     .alias('p')
     .command('workspace [NAME] [options]', 'list stories matching saved workspace query', {


### PR DESCRIPTION
## Summary

- Add `short docs` command to list and search Shortcut Docs
- Add `short doc` command to view, create, update, and delete individual docs
- Update README with documentation for new docs commands and existing epic create command

## New Commands

**`short docs`** (alias: `short d`)
- List all docs or search by title
- Filter options: `--archived`, `--mine`, `--following` (require `--title`)

**`short doc <subcommand>`**
- `view <id>` - View a doc (also works as `short doc <uuid>`)
- `create` - Create a new doc with `--title` and `--content`
- `update <id>` - Update title and/or content
- `delete <id>` - Delete a doc (requires `--confirm`)

## Example Usage

```sh
# List all docs
short docs

# Search docs by title
short docs -t "meeting notes"

# View a doc
short doc view abc-123-uuid

# Create a doc with markdown
short doc create -t "My Doc" -c "# Hello" --markdown

# Update a doc
short doc update abc-123-uuid -t "New Title"

# Delete a doc
short doc delete abc-123-uuid --confirm
```