### PR TITLE
Add AI agent onboarding: AGENTS.md, Claude Code plugin (skills + configure wizard)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+    "name": "shortcut-cli",
+    "owner": {
+        "name": "shortcut-cli"
+    },
+    "description": "Shortcut (shortcut.com) agent skills: deterministic `short` CLI recipes and a per-repo configure wizard.",
+    "plugins": [
+        {
+            "name": "shortcut-cli",
+            "source": "./.claude",
+            "description": "Use Shortcut from any repo via the deterministic `short` CLI — skills and a configure wizard that replace a Shortcut MCP server.",
+            "homepage": "https://github.com/shortcut-cli/shortcut-cli#readme",
+            "repository": "https://github.com/shortcut-cli/shortcut-cli.git",
+            "license": "MIT",
+            "keywords": ["shortcut", "cli", "skills", "mcp-replacement", "claude-code", "plugin"]
+        }
+    ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+    "name": "shortcut-cli",
+    "version": "5.0.0",
+    "description": "Use Shortcut (shortcut.com) from any repo via the deterministic `short` CLI — skills and a configure wizard that replace a Shortcut MCP server.",
+    "license": "MIT",
+    "homepage": "https://github.com/shortcut-cli/shortcut-cli#readme",
+    "repository": "https://github.com/shortcut-cli/shortcut-cli.git",
+    "keywords": ["shortcut", "cli", "skills", "mcp-replacement", "claude-code", "plugin"]
+}

--- a/.claude/commands/shortcut-configure.md
+++ b/.claude/commands/shortcut-configure.md
@@ -1,0 +1,26 @@
+# Configure Shortcut for this repo
+
+Interactive wizard that writes `.shortcut.json` at the repo root — per-repo defaults the `shortcut` skill applies to its recipes. Follow these steps in order; team, workflow, and state names come verbatim from the live API — never guessed. Only the workspace slug and story type come from the user.
+
+1. **Check the CLI and token.** Run `short --help` (root help needs no token). If `short` is not on PATH, tell the user to run `npm install -g @shortcut-cli/shortcut-cli` and stop. Then run `short api /member`: exit code 11 means no token — tell the user to set `SHORTCUT_API_TOKEN` or create `~/.config/shortcut-cli/config.json` with `{"token": "..."}` and stop. Any other non-zero exit means the token was rejected or the API is unreachable — show the error output (a 401 body means the token is invalid or revoked; have the user issue a fresh one) and stop. On success, note the `mention_name` from the JSON and suggest the user export it as `SHORTCUT_MENTION_NAME` — it is personal, so it belongs in their env rather than `.shortcut.json`, and it enables `%self%` searches and silences the config warning.
+2. **Fetch live options.** Run `short teams -a` and `short workflows`. These list the real team names and the workflows with their state names and ids.
+3. **Ask the user** (AskUserQuestion, one question per topic, options taken verbatim from step 2's output):
+    - which team is this repo's default,
+    - which workflow the team uses,
+    - which state new stories start in (offer that workflow's states),
+    - the default story type (`feature`, `bug`, or `chore`).
+4. **Determine the workspace slug.** Use `SHORTCUT_URL_SLUG` if set; otherwise ask the user (it is the `<slug>` in `https://app.shortcut.com/<slug>/...`).
+5. **Write `.shortcut.json`** at the repo root, exactly this shape, and show it to the user:
+
+```json
+{
+    "urlSlug": "<workspace-slug>",
+    "team": "<team name>",
+    "workflow": "<workflow name>",
+    "defaultState": "<state name>",
+    "defaultStateId": <state id>,
+    "defaultStoryType": "feature"
+}
+```
+
+No secrets go in this file — the token stays in env or `~/.config/shortcut-cli/config.json`. The file is meant to be committed. Personal settings (`SHORTCUT_MENTION_NAME`) stay in the user's env, not here.

--- a/.claude/skills/run-shortcut-cli/SKILL.md
+++ b/.claude/skills/run-shortcut-cli/SKILL.md
@@ -23,7 +23,7 @@ Build output lands in `build/` (entry: `build/bin/short.js`).
 The driver is the primary handle. Three modes:
 
 ```bash
-# Full smoke sweep: boots the mock, runs 14 representative commands
+# Full smoke sweep: boots the mock, runs 15 representative commands
 # (lists, story view/update, create, search, raw api GET/POST, missing-token
 # exit code), asserts on exit codes + output, prints PASS/FAIL per check.
 node .claude/skills/run-shortcut-cli/driver.mjs smoke
@@ -40,6 +40,9 @@ SHORTCUT_API_TOKEN=<token> node .claude/skills/run-shortcut-cli/driver.mjs smoke
 # Run ONE CLI command against the mock (boots + tears down around it):
 node .claude/skills/run-shortcut-cli/driver.mjs run -- story 123 -f '%j'
 node .claude/skills/run-shortcut-cli/driver.mjs run -- api /member
+
+# Or against the LIVE API — no read-only guard, this runs exactly what you pass:
+SHORTCUT_API_TOKEN=<token> node .claude/skills/run-shortcut-cli/driver.mjs run --live -- api /member
 ```
 
 ```bash
@@ -73,7 +76,7 @@ npx -y pnpm@10.32.0 run ci            # build + test + format check — what CI 
 
 - **Even subcommand `--help` exits 11 without a token** — subcommand entrypoints import `src/lib/client.ts`, which loads config at import time, before commander parses. Bare `short --help` (root help) works tokenless. Prefix with `SHORTCUT_API_TOKEN=x` to read subcommand help: `SHORTCUT_API_TOKEN=x node build/bin/short.js create --help`.
 - **`short members` / `short teams` print nothing against the mock** — the spec's canned member is `disabled: true` and the canned team `archived: true`, and the CLI hides both by default. Use `members -d` and `teams -a`.
-- **Operator search hangs against the mock** — the canned `/search/stories` response has `next: "string"` (truthy), so `short search 'state:started'` paginates forever. The driver's 30s per-command timeout would kill it; it is deliberately not in the smoke sweep. Filter-flag search (`search -t foo -q`) and `api /search/stories` are unaffected.
+- **`*SearchResults.next` needs a patched spec** — Prism's static sampler ignores `x-nullable` on required fields and synthesizes the literal string `"string"` for `next`, which is truthy and makes pagination (`while (result.data.next)` in `src/lib/stories.ts`) loop forever. `test/scripts/patch-spec.mjs` sets `example: null` on every `*SearchResults.next` field (5 as of writing) so a single mock page terminates pagination; this runs automatically via `pnpm test:update-spec` and has already been applied to the committed fixture.
 - **Mock ids are all `1`** — the canned workflow state id is `1`, so `create -t Title -s 1` is the working create invocation. `create -s 500000` prints `State 500000 not found` **and still exits 0**.
 - **Search's text flag is `-t/--text`** (regex), not `--title`. Positional args are Shortcut search operators (e.g. `state:started`); `%self%` in a query expands to your mention name.
 - **Port 4010 belongs to vitest** — its global setup boots the same mock there. The driver uses 4013 so `smoke` and `pnpm test` can run side by side.

--- a/.claude/skills/run-shortcut-cli/SKILL.md
+++ b/.claude/skills/run-shortcut-cli/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: run-shortcut-cli
+description: Build, run, test, and drive the shortcut-cli (`short`) — against the live Shortcut API or a deterministic local mock. Use when asked to run shortcut-cli, start it, smoke-test it, try a `short` command with or without real credentials, or verify a change works in the real CLI.
+---
+
+shortcut-cli is a commander-based CLI (`short`) for shortcut.com. Drive it via `.claude/skills/run-shortcut-cli/driver.mjs`, which boots the repo's own Prism mock server (spec-generated responses, fully deterministic — no token, no network) and runs the built CLI against it. All paths are relative to the repo root.
+
+## Prerequisites
+
+Node >= 20.19. pnpm is pinned via `packageManager`; if pnpm is not on PATH, `npx -y pnpm@10.32.0` works identically.
+
+## Setup + Build
+
+```bash
+npx -y pnpm@10.32.0 install --frozen-lockfile
+npx -y pnpm@10.32.0 run build
+```
+
+Build output lands in `build/` (entry: `build/bin/short.js`).
+
+## Run (agent path)
+
+The driver is the primary handle. Three modes:
+
+```bash
+# Full smoke sweep: boots the mock, runs 14 representative commands
+# (lists, story view/update, create, search, raw api GET/POST, missing-token
+# exit code), asserts on exit codes + output, prints PASS/FAIL per check.
+node .claude/skills/run-shortcut-cli/driver.mjs smoke
+# → "[driver] smoke: all checks passed", exit 0
+```
+
+```bash
+# Read-only sweep against the LIVE Shortcut API (auth, reads, server-side search).
+# Needs a real token; never creates or updates anything:
+SHORTCUT_API_TOKEN=<token> node .claude/skills/run-shortcut-cli/driver.mjs smoke --live
+```
+
+```bash
+# Run ONE CLI command against the mock (boots + tears down around it):
+node .claude/skills/run-shortcut-cli/driver.mjs run -- story 123 -f '%j'
+node .claude/skills/run-shortcut-cli/driver.mjs run -- api /member
+```
+
+```bash
+# Keep the mock in the foreground (port 4013; override with PRISM_PORT),
+# then in another shell point the CLI at it yourself:
+node .claude/skills/run-shortcut-cli/driver.mjs mock
+SHORTCUT_API_TOKEN=x SHORTCUT_URL_SLUG=w SHORTCUT_MENTION_NAME=m \
+  SHORTCUT_API_BASE_URL=http://127.0.0.1:4013 node build/bin/short.js epics
+```
+
+The driver injects a fake token, slug, and mention name, points `SHORTCUT_API_BASE_URL` at the mock, and isolates `XDG_CONFIG_HOME` so a real `~/.config/shortcut-cli` never leaks in.
+
+## Run (human path)
+
+Against the real API — set a real token (get one at Shortcut → Settings → API Tokens):
+
+```bash
+SHORTCUT_API_TOKEN=<token> node build/bin/short.js search -t 'some title' -q
+```
+
+For day-to-day _usage_ recipes (search operators, create/update, raw API), see the `shortcut` skill (`.claude/skills/shortcut/SKILL.md`).
+
+## Test
+
+```bash
+npx -y pnpm@10.32.0 run test          # vitest + coverage, boots its own mock on port 4010
+npx -y pnpm@10.32.0 run ci            # build + test + format check — what CI runs
+```
+
+## Gotchas
+
+- **Even subcommand `--help` exits 11 without a token** — subcommand entrypoints import `src/lib/client.ts`, which loads config at import time, before commander parses. Bare `short --help` (root help) works tokenless. Prefix with `SHORTCUT_API_TOKEN=x` to read subcommand help: `SHORTCUT_API_TOKEN=x node build/bin/short.js create --help`.
+- **`short members` / `short teams` print nothing against the mock** — the spec's canned member is `disabled: true` and the canned team `archived: true`, and the CLI hides both by default. Use `members -d` and `teams -a`.
+- **Operator search hangs against the mock** — the canned `/search/stories` response has `next: "string"` (truthy), so `short search 'state:started'` paginates forever. The driver's 30s per-command timeout would kill it; it is deliberately not in the smoke sweep. Filter-flag search (`search -t foo -q`) and `api /search/stories` are unaffected.
+- **Mock ids are all `1`** — the canned workflow state id is `1`, so `create -t Title -s 1` is the working create invocation. `create -s 500000` prints `State 500000 not found` **and still exits 0**.
+- **Search's text flag is `-t/--text`** (regex), not `--title`. Positional args are Shortcut search operators (e.g. `state:started`); `%self%` in a query expands to your mention name.
+- **Port 4010 belongs to vitest** — its global setup boots the same mock there. The driver uses 4013 so `smoke` and `pnpm test` can run side by side.
+- **oxfmt formats markdown** — any `.md` you add must pass `npx -y pnpm@10.32.0 run test:format` or CI fails.
+
+## Troubleshooting
+
+- **`Please run 'short install' to configure Shortcut API access` (exit 11)**: no token in env or `~/.config/shortcut-cli/config.json`. Set `SHORTCUT_API_TOKEN`.
+- **`error: unknown option '--title'`**: search filters by `-t/--text`; run `SHORTCUT_API_TOKEN=x node build/bin/short.js search --help` for the flag list.

--- a/.claude/skills/run-shortcut-cli/driver.mjs
+++ b/.claude/skills/run-shortcut-cli/driver.mjs
@@ -6,13 +6,18 @@
  * Run from the repo root, after `pnpm install` and `pnpm build`:
  *
  *   node .claude/skills/run-shortcut-cli/driver.mjs smoke        # sweep + assertions vs mock
- *   node .claude/skills/run-shortcut-cli/driver.mjs smoke --live # read-only sweep vs LIVE API
+ *   node .claude/skills/run-shortcut-cli/driver.mjs smoke --live # fixed, read-only sweep vs LIVE API
  *   node .claude/skills/run-shortcut-cli/driver.mjs mock         # foreground mock server
  *   node .claude/skills/run-shortcut-cli/driver.mjs run -- search -t foo -q
  *                                                                # one CLI command vs mock
+ *   node .claude/skills/run-shortcut-cli/driver.mjs run --live -- api /member
+ *                                                                # one CLI command vs LIVE API
  *
- * Live mode uses your real credentials (SHORTCUT_API_TOKEN env or
- * ~/.config/shortcut-cli/config.json) and only ever READS — no create/update.
+ * `smoke --live` runs a fixed, hand-picked set of read-only checks — it never creates
+ * or updates anything. `run --live` executes WHATEVER CLI ARGS YOU PASS against the
+ * real API with your real credentials (SHORTCUT_API_TOKEN env or
+ * ~/.config/shortcut-cli/config.json) — including mutating commands like `create` or
+ * `api -X POST`. There is no built-in read-only guard on `run --live`; that's on you.
  * Mock port defaults to 4013 (vitest owns 4010); override with PRISM_PORT.
  */
 import { execFile } from 'child_process';
@@ -117,8 +122,11 @@ const CHECKS = [
         expect: (r) => r.exitCode === 0 && Boolean(JSON.parse(r.stdout)),
     },
     { name: 'search', args: ['search', '-t', 'foo', '-q'], expect: (r) => r.exitCode === 0 },
-    // NOTE: operator search (`search 'state:started'`) is deliberately absent: the mock's
-    // canned /search/stories response has next:"string", which makes pagination loop forever.
+    {
+        name: 'search with operators',
+        args: ['search', '-q', 'state:started'],
+        expect: (r) => r.exitCode === 0,
+    },
     { name: 'iterations list', args: ['iterations'], expect: (r) => r.exitCode === 0 },
     // -a: the mock's canned team is archived:true, and the CLI hides archived teams by default
     {
@@ -238,15 +246,17 @@ async function main() {
         return; // server keeps the event loop alive
     }
     if (mode === 'run') {
-        const args = rest[0] === '--' ? rest.slice(1) : rest;
-        const server = await startMock();
-        const r = await runCli(args);
-        await server.close();
+        const live = rest[0] === '--live';
+        const dashIndex = rest.indexOf('--');
+        const args = dashIndex >= 0 ? rest.slice(dashIndex + 1) : rest.slice(live ? 1 : 0);
+        const server = live ? null : await startMock();
+        const r = await runCli(args, {}, { live });
+        if (server) await server.close();
         process.stdout.write(r.stdout);
         process.stderr.write(r.stderr);
         process.exit(r.exitCode);
     }
-    console.error('Usage: driver.mjs <smoke|mock|run -- <cli args...>>');
+    console.error('Usage: driver.mjs <smoke [--live] | mock | run [--live] -- <cli args...>>');
     process.exit(2);
 }
 

--- a/.claude/skills/run-shortcut-cli/driver.mjs
+++ b/.claude/skills/run-shortcut-cli/driver.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+/**
+ * Driver for shortcut-cli: boots the same Prism mock the test suite uses
+ * (spec-driven, deterministic responses) and runs the built CLI against it.
+ *
+ * Run from the repo root, after `pnpm install` and `pnpm build`:
+ *
+ *   node .claude/skills/run-shortcut-cli/driver.mjs smoke        # sweep + assertions vs mock
+ *   node .claude/skills/run-shortcut-cli/driver.mjs smoke --live # read-only sweep vs LIVE API
+ *   node .claude/skills/run-shortcut-cli/driver.mjs mock         # foreground mock server
+ *   node .claude/skills/run-shortcut-cli/driver.mjs run -- search -t foo -q
+ *                                                                # one CLI command vs mock
+ *
+ * Live mode uses your real credentials (SHORTCUT_API_TOKEN env or
+ * ~/.config/shortcut-cli/config.json) and only ever READS — no create/update.
+ * Mock port defaults to 4013 (vitest owns 4010); override with PRISM_PORT.
+ */
+import { execFile } from 'child_process';
+import { mkdtempSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const SPEC_PATH = path.join(REPO_ROOT, 'test/fixtures/shortcut.swagger.json');
+const CLI = path.join(REPO_ROOT, 'build/bin/short.js');
+const PORT = Number.parseInt(process.env.PRISM_PORT ?? '4013', 10);
+if (!Number.isInteger(PORT) || PORT < 1 || PORT > 65535) {
+    console.error(`[driver] invalid PRISM_PORT: ${process.env.PRISM_PORT}`);
+    process.exit(2);
+}
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+async function startMock() {
+    const { getHttpOperationsFromSpec } = await import('@stoplight/prism-http');
+    const { createServer } = await import('@stoplight/prism-http-server');
+    const pino = (await import('pino')).default;
+    const operations = await getHttpOperationsFromSpec(SPEC_PATH);
+    const server = createServer(operations, {
+        cors: true,
+        config: {
+            checkSecurity: false,
+            validateRequest: false,
+            validateResponse: false,
+            mock: { dynamic: false },
+            errors: false,
+            upstreamProxy: undefined,
+            isProxy: false,
+        },
+        components: { logger: pino({ level: 'silent', customLevels: { success: 32 } }) },
+    });
+    await server.listen(PORT, '127.0.0.1');
+    return server;
+}
+
+// One isolated config dir per driver run, shared across mock invocations
+let mockConfigDir;
+
+function runCli(args, envOverrides = {}, { live = false } = {}) {
+    // live: real credentials, real API. mock: fake credentials, Prism, isolated config dir.
+    const env = live
+        ? { ...process.env, ...envOverrides }
+        : {
+              ...process.env,
+              SHORTCUT_API_TOKEN: 'driver-token',
+              SHORTCUT_URL_SLUG: 'driver-workspace',
+              SHORTCUT_MENTION_NAME: 'driver-user',
+              SHORTCUT_API_BASE_URL: BASE_URL,
+              // isolate from any real ~/.config/shortcut-cli
+              XDG_CONFIG_HOME: (mockConfigDir ??= mkdtempSync(
+                  path.join(os.tmpdir(), 'short-driver-')
+              )),
+              ...envOverrides,
+          };
+    return new Promise((resolve) => {
+        execFile(
+            process.execPath,
+            [CLI, ...args],
+            {
+                cwd: REPO_ROOT,
+                timeout: 30_000,
+                env,
+            },
+            (error, stdout, stderr) => {
+                resolve({
+                    // error.code can be a string (e.g. ENOENT on spawn failure) — only trust numbers
+                    exitCode: error ? (typeof error.code === 'number' ? error.code : 1) : 0,
+                    stdout: String(stdout ?? ''),
+                    stderr: String(stderr ?? ''),
+                });
+            }
+        );
+    });
+}
+
+const CHECKS = [
+    {
+        name: 'workflows list',
+        args: ['workflows'],
+        expect: (r) => r.exitCode === 0 && r.stdout.trim().length > 0,
+    },
+    { name: 'epics list', args: ['epics'], expect: (r) => r.exitCode === 0 },
+    // -d: the Prism mock's canned member is disabled:true, and the CLI hides disabled members by default
+    {
+        name: 'members list',
+        args: ['members', '-d'],
+        expect: (r) => r.exitCode === 0 && r.stdout.trim().length > 0,
+    },
+    {
+        name: 'story view',
+        args: ['story', '123'],
+        expect: (r) => r.exitCode === 0 && /#\d+/.test(r.stdout),
+    },
+    {
+        name: 'story view as JSON (%j)',
+        args: ['story', '123', '-f', '%j'],
+        expect: (r) => r.exitCode === 0 && Boolean(JSON.parse(r.stdout)),
+    },
+    { name: 'search', args: ['search', '-t', 'foo', '-q'], expect: (r) => r.exitCode === 0 },
+    // NOTE: operator search (`search 'state:started'`) is deliberately absent: the mock's
+    // canned /search/stories response has next:"string", which makes pagination loop forever.
+    { name: 'iterations list', args: ['iterations'], expect: (r) => r.exitCode === 0 },
+    // -a: the mock's canned team is archived:true, and the CLI hides archived teams by default
+    {
+        name: 'teams list',
+        args: ['teams', '-a'],
+        expect: (r) => r.exitCode === 0 && r.stdout.trim().length > 0,
+    },
+    { name: 'labels list', args: ['labels'], expect: (r) => r.exitCode === 0 },
+    // -s 1: the mock's canned workflow state id; create resolves the state before POSTing
+    {
+        name: 'create story',
+        args: ['create', '-t', 'Driver test', '-s', '1'],
+        expect: (r) => r.exitCode === 0 && r.stdout.includes('#1'),
+    },
+    {
+        name: 'story update (comment)',
+        args: ['story', '123', '-c', 'driver comment', '-f', '%id'],
+        expect: (r) => r.exitCode === 0 && r.stdout.trim().length > 0,
+    },
+    {
+        name: 'raw api GET → JSON',
+        args: ['api', '/member'],
+        expect: (r) => r.exitCode === 0 && Boolean(JSON.parse(r.stdout)),
+    },
+    {
+        name: 'raw api POST → JSON',
+        args: [
+            'api',
+            '/stories',
+            '-X',
+            'POST',
+            '-f',
+            'name=Driver story',
+            '-f',
+            'workflow_state_id=1',
+        ],
+        expect: (r) => r.exitCode === 0 && Boolean(JSON.parse(r.stdout)),
+    },
+    {
+        name: 'missing token → exit 11',
+        args: ['members'],
+        env: { SHORTCUT_API_TOKEN: '' },
+        expect: (r) => r.exitCode === 11,
+    },
+];
+
+// READ-ONLY live sweep: proves auth + reads + server-side search against the real API.
+// Deliberately no create/update — this runs against a real workspace.
+const LIVE_CHECKS = [
+    {
+        name: 'identity (api /member)',
+        args: ['api', '/member'],
+        expect: (r) => r.exitCode === 0 && Boolean(JSON.parse(r.stdout).mention_name),
+    },
+    {
+        name: 'workflows list',
+        args: ['workflows'],
+        expect: (r) => r.exitCode === 0 && r.stdout.trim().length > 0,
+    },
+    { name: 'epics list', args: ['epics'], expect: (r) => r.exitCode === 0 },
+    {
+        name: 'members list',
+        args: ['members', '-d'],
+        expect: (r) => r.exitCode === 0 && r.stdout.trim().length > 0,
+    },
+    {
+        name: 'server-side operator search (bounded)',
+        args: ['api', '/search/stories', '-f', 'query=is:story', '-f', 'page_size=1'],
+        expect: (r) => r.exitCode === 0 && Array.isArray(JSON.parse(r.stdout).data),
+    },
+];
+
+async function smoke(live) {
+    let server = null;
+    let checks = CHECKS;
+    if (live) {
+        checks = LIVE_CHECKS;
+        console.log('[driver] LIVE mode: read-only sweep against the real Shortcut API');
+    } else {
+        server = await startMock();
+        console.log(`[driver] Prism mock listening on ${BASE_URL}`);
+    }
+    let failed = 0;
+    try {
+        for (const check of checks) {
+            const r = await runCli(check.args, check.env ?? {}, { live });
+            let ok = false;
+            try {
+                ok = check.expect(r);
+            } catch {
+                ok = false;
+            }
+            console.log(`${ok ? 'PASS' : 'FAIL'}  ${check.name}  (exit ${r.exitCode})`);
+            if (!ok) {
+                failed++;
+                console.log(`      stdout: ${r.stdout.slice(0, 300)}`);
+                console.log(`      stderr: ${r.stderr.slice(0, 300)}`);
+            }
+        }
+    } finally {
+        if (server) await server.close();
+    }
+    console.log(
+        failed === 0
+            ? '[driver] smoke: all checks passed'
+            : `[driver] smoke: ${failed} check(s) FAILED`
+    );
+    process.exit(failed === 0 ? 0 : 1);
+}
+
+async function main() {
+    const [mode, ...rest] = process.argv.slice(2);
+    if (mode === 'smoke') return smoke(rest.includes('--live'));
+    if (mode === 'mock') {
+        await startMock();
+        console.log(`[driver] Prism mock listening on ${BASE_URL} (Ctrl-C to stop)`);
+        return; // server keeps the event loop alive
+    }
+    if (mode === 'run') {
+        const args = rest[0] === '--' ? rest.slice(1) : rest;
+        const server = await startMock();
+        const r = await runCli(args);
+        await server.close();
+        process.stdout.write(r.stdout);
+        process.stderr.write(r.stderr);
+        process.exit(r.exitCode);
+    }
+    console.error('Usage: driver.mjs <smoke|mock|run -- <cli args...>>');
+    process.exit(2);
+}
+
+main();

--- a/.claude/skills/shortcut/SKILL.md
+++ b/.claude/skills/shortcut/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: shortcut
+description: Query and update Shortcut (shortcut.com) deterministically via the `short` CLI — search stories, view/create/update stories, epics, iterations, teams, members, labels, workflows, or call any Shortcut REST v3 endpoint. Use instead of a Shortcut MCP server whenever asked to look something up in Shortcut or change it.
+---
+
+The `short` CLI is a full replacement for a Shortcut MCP server: env-only auth, a typed command per resource, and a raw-API escape hatch that covers every REST v3 endpoint with JSON output. Every recipe below is deterministic — fixed flags, parseable output, meaningful exit codes.
+
+## Auth (no interactive setup needed)
+
+```bash
+export SHORTCUT_API_TOKEN=<token>        # required — Shortcut → Settings → API Tokens
+                                         # (alternative: {"token": "..."} in ~/.config/shortcut-cli/config.json)
+export SHORTCUT_URL_SLUG=<workspace>     # optional — used to build story URLs
+export SHORTCUT_MENTION_NAME=<mention>   # optional — enables %self% in search queries
+```
+
+Missing token → exit code **11** on every subcommand (including `<subcommand> --help`; bare `short --help` works tokenless). Missing slug/mention-name still works but prints a `shortcut-cli: … not configured` warning to **stderr** per missing value on every invocation — set them (or their config-file equivalents) to keep script output clean.
+
+`short` comes from a global install (`npm install -g @shortcut-cli/shortcut-cli`). Only when working inside the shortcut-cli repo itself, `node build/bin/short.js` (after `pnpm build`) is the equivalent dev fallback.
+
+## Per-repo defaults (`.shortcut.json`)
+
+If the repo root has a `.shortcut.json`, read it and apply its values to every recipe below:
+
+```json
+{
+    "urlSlug": "<workspace-slug>",
+    "team": "<team name>",
+    "workflow": "<workflow name>",
+    "defaultState": "<state name>",
+    "defaultStateId": <state id>,
+    "defaultStoryType": "feature"
+}
+```
+
+- Pass `urlSlug` as `SHORTCUT_URL_SLUG` in the command's env (correct story URLs, no stderr warning) — note this only takes effect when `~/.config/shortcut-cli/config.json` has no `urlSlug`; for slug and mention name the config file wins and env fills gaps. (`SHORTCUT_API_TOKEN` is the opposite: env beats the config file.)
+- Default `create` to `-T <team> -s <defaultStateId> -y <defaultStoryType>` (the numeric id — name matching is regex-based and can hit the wrong state) unless the request says otherwise; scope searches to the team when it makes sense.
+- Precedence: explicit request > `.shortcut.json` defaults > CLI config. This holds unconditionally for `team`/`defaultStateId`/`defaultStoryType` (applied as command flags, which always win); `urlSlug` is applied via env and therefore subject to the caveat above (a `urlSlug` in the user's config file still wins).
+- The file is committed and secret-free (the token never goes in it). To create or update it, run the `/shortcut-cli:shortcut-configure` wizard.
+
+## The universal tool: `short api`
+
+Any endpoint, always JSON on stdout — when no typed command fits, this is the answer:
+
+```bash
+short api /member                                              # GET, current member
+short api /search/stories -f query='state:started' -f page_size=2   # GET with query params
+short api /stories -X POST -f name='My story' -f workflow_state_id=1  # write (POST/PUT/DELETE)
+```
+
+`-f key=value` becomes query params on GET and the JSON body on POST/PUT/PATCH. Pipe to `jq` for extraction. Paths are relative to `/api/v3`.
+
+## Stories
+
+```bash
+short story 123 -f '%j'                    # full story as JSON (%j = JSON template token)
+short story 123 -c 'comment text' -f '%id' # add comment; print only the id
+short create -t 'Title' -s <state-id-or-name>   # create (also: -d desc, -e estimate, -o owners, --epic, -i iteration, -y bug|feature|chore)
+```
+
+`short story` also updates: `-s state`, `-o owners`, `-e estimate`, `--epic`, `-i iteration`, `-a` (archive), `--move-up/--move-down`. Run `SHORTCUT_API_TOKEN=x short story --help` for the full list.
+
+## Search
+
+```bash
+short search -q -t 'title regex' -f '%j'   # client-side filters (-t text, -o owner, -s state, -l label), JSON per story
+short search -q 'state:started'            # positional args = Shortcut search operators, incl. owner:%self%
+```
+
+`-q` suppresses the loading spinner — always pass it in scripts. For server-side search with exact JSON, prefer `short api /search/stories -f query='...'` (same operators; this form is also what the hermetic mock verifies — operator search via `short search` hangs against the mock, see the `run-shortcut-cli` skill gotchas).
+
+## Other resources
+
+```bash
+# list
+short epics          # epics with ids and states
+short iterations     # iterations
+short teams          # teams (groups)
+short members -d     # members; -d includes disabled ones (omitting it silently hides them)
+short labels         # labels
+short workflows      # workflows and their state ids (needed for create -s)
+
+# view one resource (human-readable — prefer over `api /<x>/<id>` + jq)
+short epic view <id>         # also: epic stories <id>, epic comments <id>, epic update <id>
+short iteration view <id>    # also: iteration stories <id>, create/update/delete
+short objective view <id>    # also: objective epics <id>, create/update
+short doc view <id>          # also: doc create/update/delete
+short team view <idOrName>   # `view` is the default: `short team <idOrName>` works too
+short label stories <idOrName>   # stories for a label (no bare label view; also: label epics <idOrName>)
+short custom-field <id>      # positional, no subcommand
+```
+
+The list commands print human-formatted text; when you need JSON from them, use the `api` equivalents: `/epics`, `/iterations`, `/groups`, `/members`, `/labels`, `/workflows`. For a **single** epic/iteration/objective/doc/team, reach for the `view <id>` command first — it needs no JSON parsing; use `short api /<x>/<id>` only when you need fields the view output omits.
+
+## Verifying the toolchain
+
+Everything above targets the **live API** — that is the normal mode of this skill. To confirm auth and connectivity before real work, run the read-only live sweep:
+
+```bash
+SHORTCUT_API_TOKEN=<token> node .claude/skills/run-shortcut-cli/driver.mjs smoke --live
+```
+
+Without credentials (CI, development on the CLI itself), the repo's Prism mock serves the whole API from the swagger spec:
+
+```bash
+node .claude/skills/run-shortcut-cli/driver.mjs smoke            # hermetic sweep vs mock
+node .claude/skills/run-shortcut-cli/driver.mjs run -- epics     # one command vs mock
+```
+
+See the `run-shortcut-cli` skill for building the CLI and mock quirks.
+
+## Gotchas
+
+- Exit code **11** = missing token (even for subcommand `--help`). Exit 0 does **not** always mean success: `create` with an unknown state prints `State … not found` and exits 0 — check output, not just the code.
+- `%j` on `story`/`search` gives JSON; most list commands don't have a JSON flag — use `short api` when output must be parsed.
+- Capture **stdout only** — the spinner and `… not configured` warnings go to stderr, and merging with `2>&1` mixes spinner control codes into the data. `-q` (where supported) suppresses the spinner.
+- Story/epic/iteration/state/label flags accept id **or** name (matched by regex) — ids are unambiguous, prefer them in automation.

--- a/.claude/skills/shortcut/SKILL.md
+++ b/.claude/skills/shortcut/SKILL.md
@@ -67,7 +67,7 @@ short search -q -t 'title regex' -f '%j'   # client-side filters (-t text, -o ow
 short search -q 'state:started'            # positional args = Shortcut search operators, incl. owner:%self%
 ```
 
-`-q` suppresses the loading spinner — always pass it in scripts. For server-side search with exact JSON, prefer `short api /search/stories -f query='...'` (same operators; this form is also what the hermetic mock verifies — operator search via `short search` hangs against the mock, see the `run-shortcut-cli` skill gotchas).
+`-q` suppresses the loading spinner — always pass it in scripts. For server-side search with exact JSON, prefer `short api /search/stories -f query='...'` (same operators).
 
 ## Other resources
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+Follow the agent guidance in [AGENTS.md](../AGENTS.md) at the repository root.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository. Human-facing usage docs live in [README.md](README.md).
+
+## Project overview
+
+`shortcut-cli` is a community-driven command line tool for [Shortcut](https://shortcut.com) (stories, epics, iterations, docs, teams, and raw API access). It ships a single `short` binary built with [commander](https://github.com/tj/commander.js), published to npm as `@shortcut-cli/shortcut-cli`.
+
+## Layout
+
+- `src/bin/short.ts` — root command; `src/bin/short-<name>.ts` — one file per subcommand (e.g. `short-story.ts`, `short-search.ts`).
+- `src/lib/` — shared code: `client.ts` (Shortcut API client via `@shortcut/client`), `configure.ts` (token/workspace config), `stories.ts`, `spinner.ts`.
+- `test/` mirrors `src/`: `test/bin/*.spec.ts`, `test/lib/*.spec.ts`. Tests run against a [Prism](https://github.com/stoplightio/prism) mock server fed by the Shortcut swagger spec in `test/fixtures/` (started in `test/global-setup.ts`).
+- `build/` — tsdown output (gitignored); the published artifact.
+
+## Toolchain and commands
+
+pnpm only (version pinned via `packageManager` in package.json), Node >= 20.19.
+
+| Command            | What it does                     |
+| ------------------ | -------------------------------- |
+| `pnpm install`     | Install dependencies             |
+| `pnpm build`       | Bundle with tsdown into `build/` |
+| `pnpm test`        | vitest run with coverage         |
+| `pnpm test:watch`  | vitest watch mode                |
+| `pnpm lint`        | oxlint                           |
+| `pnpm format`      | oxfmt (write)                    |
+| `pnpm test:format` | oxfmt check (CI mode)            |
+| `pnpm type-check`  | tsc --noEmit                     |
+| `pnpm ci`          | build + test + format check      |
+| `pnpm start`       | Run the built CLI (`short`)      |
+
+Run `pnpm build && pnpm test && pnpm test:format && pnpm lint && pnpm type-check` before pushing — CI runs each of these as a required matrix job on every PR.
+
+## Conventions
+
+- ESM throughout (`"type": "module"`).
+- Formatting is owned by oxfmt (`.oxfmtrc.json`): 4-space indent, single quotes, 100-char lines, sorted imports. It also formats markdown and JSON. Don't hand-format; run `pnpm format`.
+- Linting rules live in `.oxlintrc.json`.
+- No new runtime dependencies without prior discussion in an issue — the dependency footprint is deliberately small.
+- Behavior changes require tests. New subcommands get a matching `test/bin/short-<name>.spec.ts` against the Prism mock.
+- The Shortcut API surface comes from the swagger spec; refresh it with `pnpm test:update-spec`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This is a community-driven command line interface for [Shortcut](https://shortcu
     - [Workflows](#workflows)
     - [Projects](#projects)
     - [API](#api)
+- [Claude Code Plugin](#claude-code-plugin)
 - [Development](#development)
 - [Acknowledgments](#acknowledgments)
 
@@ -1027,6 +1028,21 @@ Delete a doc:
     # jq can be used to shorten the response output.
     $ short api /search/iterations -f page_size=10 -f query=123 | jq '.data[] | {id, name}'
 ```
+
+## Claude Code Plugin
+
+This repo ships a [Claude Code](https://claude.com/claude-code) plugin so AI agents can use Shortcut deterministically via `short` instead of an MCP server. Install it in any repo:
+
+```
+/plugin marketplace add shortcut-cli/shortcut-cli
+/plugin install shortcut-cli@shortcut-cli
+```
+
+It needs `short` on `PATH` (`npm install -g @shortcut-cli/shortcut-cli`) and a token (see [Install](#install) above). The plugin provides:
+
+- **`shortcut`** skill — usage recipes for searching, viewing, creating, and updating stories, epics, iterations, and more, plus the `short api` escape hatch for anything else.
+- **`run-shortcut-cli`** skill — build/test/smoke-test the CLI itself, including a hermetic mock mode with no credentials required.
+- **`/shortcut-cli:shortcut-configure`** — a wizard that reads your teams and workflows from the live API and writes a per-repo `.shortcut.json` (default team, workflow, starting state, story type) so agents don't have to guess or ask every time.
 
 ## Development
 

--- a/test/fixtures/shortcut.swagger.json
+++ b/test/fixtures/shortcut.swagger.json
@@ -2417,7 +2417,8 @@
         "next": {
           "description": "The URL path and query string for the next page of search results.",
           "type": "string",
-          "x-nullable": true
+          "x-nullable": true,
+          "example": null
         }
       },
       "additionalProperties": false,
@@ -3188,7 +3189,8 @@
         "next": {
           "description": "The URL path and query string for the next page of search results.",
           "type": "string",
-          "x-nullable": true
+          "x-nullable": true,
+          "example": null
         }
       },
       "additionalProperties": false,
@@ -5995,7 +5997,8 @@
         "next": {
           "description": "The URL path and query string for the next page of search results.",
           "type": "string",
-          "x-nullable": true
+          "x-nullable": true,
+          "example": null
         }
       },
       "additionalProperties": false,
@@ -7336,7 +7339,8 @@
         "next": {
           "description": "The URL path and query string for the next page of search results.",
           "type": "string",
-          "x-nullable": true
+          "x-nullable": true,
+          "example": null
         }
       },
       "additionalProperties": false,
@@ -9495,7 +9499,8 @@
         "next": {
           "description": "The URL path and query string for the next page of search results.",
           "type": "string",
-          "x-nullable": true
+          "x-nullable": true,
+          "example": null
         }
       },
       "additionalProperties": false,

--- a/test/scripts/patch-spec.mjs
+++ b/test/scripts/patch-spec.mjs
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 /* global console */
 /**
- * Patches the downloaded Shortcut swagger spec to add `minimum: 0` or
- * `minimum: 1` to integer fields that lack a minimum constraint.
- *
- * Without this, Prism's static mode generates -9007199254740991
- * (MIN_SAFE_INTEGER) for all int64 fields because @stoplight/http-spec
- * injects `minimum: -9007199254740991` when no minimum is specified,
- * and the sampler returns the minimum value.
+ * Patches the downloaded Shortcut swagger spec:
+ * - adds `minimum: 0` or `minimum: 1` to integer fields that lack one
+ *   (Prism's static sampler otherwise returns MIN_SAFE_INTEGER)
+ * - adds `example: null` to pagination cursor fields (`next` on
+ *   `*SearchResults`), which are `x-nullable: true` but still required —
+ *   Prism's static sampler ignores `x-nullable` for required fields and
+ *   synthesizes the literal string "string", which is truthy and makes
+ *   pagination loops (`while (result.data.next)` in src/lib/stories.ts)
+ *   run forever against the mock
  *
  * Run automatically as part of `pnpm test:update-spec`.
  */
@@ -21,6 +23,7 @@ const SPEC_PATH = resolve(__dirname, '../fixtures/shortcut.swagger.json');
 const spec = JSON.parse(readFileSync(SPEC_PATH, 'utf-8'));
 
 let patched = 0;
+let cursorsPatched = 0;
 
 /**
  * Add `minimum` to integer fields that don't have one.
@@ -65,14 +68,36 @@ function patchIntegerMinimum(schema, propName) {
     }
 }
 
+/**
+ * Force the mock's pagination cursor to null so a single-page mock
+ * response terminates pagination instead of looping forever.
+ */
+function patchPaginationCursorExample(schema, propName) {
+    if (!schema || typeof schema !== 'object') return;
+
+    // Force null unconditionally (not just when no example is set) — an upstream spec
+    // update could ship its own non-null example for `next` and silently reopen the hang.
+    if (
+        propName === 'next' &&
+        schema.type === 'string' &&
+        schema['x-nullable'] === true &&
+        schema.example !== null
+    ) {
+        schema.example = null;
+        cursorsPatched++;
+    }
+}
+
 // Walk all definitions
 for (const [, def] of Object.entries(spec.definitions || {})) {
     if (def.properties) {
         for (const [propName, propSchema] of Object.entries(def.properties)) {
             patchIntegerMinimum(propSchema, propName);
+            patchPaginationCursorExample(propSchema, propName);
         }
     }
 }
 
 writeFileSync(SPEC_PATH, JSON.stringify(spec, null, 2) + '\n');
 console.log(`[patch-spec] Patched ${patched} integer fields with minimum constraints`);
+console.log(`[patch-spec] Patched ${cursorsPatched} pagination cursor fields to example: null`);


### PR DESCRIPTION
Proposes basic AI-agent onboarding for this repo, built and verified on a fork over a few small PRs:

- **`AGENTS.md`** at the repo root — project overview, layout, verified toolchain commands, and conventions for AI coding agents. **`CLAUDE.md`** and **`.github/copilot-instructions.md`** are one-line pointers to it (no duplicated content).
- **A Claude Code plugin** (`.claude-plugin/marketplace.json`, `.claude/.claude-plugin/plugin.json`) exposing two skills and a wizard:
  - **`shortcut`** — deterministic `short`-CLI usage recipes (search, story/epic/iteration/objective/doc view & update, raw `api` escape hatch), meant to let an agent use this CLI instead of standing up a Shortcut MCP server.
  - **`run-shortcut-cli`** — build/run/smoke-test instructions plus a driver script that boots the repo's own Prism mock (or targets the live API read-only) and exercises representative commands.
  - **`/shortcut-cli:shortcut-configure`** — a wizard that reads a workspace's teams/workflows from the live API and writes a per-repo `.shortcut.json` (default team, workflow, starting state, story type), so agents don't have to ask or guess every time.
- A **README** section documenting how to install the plugin, and a small `shortcut` skill fix (singular `epic view <id>`-style detail commands were undocumented, so agents were falling back to `short api` + jq/python for single-resource reads).

## Verification

Every documented command was executed against the repo's Prism mock and, for the plugin's live-mode paths, against a real workspace (read-only). `pnpm run ci` (build, test, format check) passes. All of this is additive — no changes to `src/`, no new dependencies, no CI changes.

Happy to split this into smaller PRs, drop the plugin/skills portion, or adjust scope/placement (e.g. under `docs/` or a different plugin name) if that fits this project's direction better — this is a bundled proposal from active use on a fork, not a demand for a particular shape.
